### PR TITLE
Track if events, venues, organizers, and attendees were generated

### DIFF
--- a/src/Events/Generator/API.php
+++ b/src/Events/Generator/API.php
@@ -153,6 +153,11 @@ class Tribe__CLI__Events__Generator__API {
 
 		$event_id = tribe_create_event( $args );
 
+		// mark event, venue, and organizers as generated from tribe-cli
+		add_post_meta( $event_id, '_tribe_cli_generated', 1 );
+		add_post_meta( $venue, '_tribe_cli_generated', 1 );
+		add_post_meta( $organizer, '_tribe_cli_generated', 1 );
+
 		return $event_id;
 
 	}

--- a/src/Events/Generator/API.php
+++ b/src/Events/Generator/API.php
@@ -154,9 +154,13 @@ class Tribe__CLI__Events__Generator__API {
 		$event_id = tribe_create_event( $args );
 
 		// mark event, venue, and organizers as generated from tribe-cli
-		add_post_meta( $event_id, '_tribe_cli_generated', 1 );
-		add_post_meta( $venue, '_tribe_cli_generated', 1 );
-		add_post_meta( $organizer, '_tribe_cli_generated', 1 );
+		global $tribe_cli_container;
+
+		$key = $tribe_cli_container->getVar( 'generated-meta-key' );
+
+		add_post_meta( $event_id, $key, 1 );
+		add_post_meta( $venue, $key, 1 );
+		add_post_meta( $organizer, $key, 1 );
 
 		return $event_id;
 

--- a/src/Events/Generator/API.php
+++ b/src/Events/Generator/API.php
@@ -154,13 +154,9 @@ class Tribe__CLI__Events__Generator__API {
 		$event_id = tribe_create_event( $args );
 
 		// mark event, venue, and organizers as generated from tribe-cli
-		global $tribe_cli_container;
-
-		$key = $tribe_cli_container->getVar( 'generated-meta-key' );
-
-		add_post_meta( $event_id, $key, 1 );
-		add_post_meta( $venue, $key, 1 );
-		add_post_meta( $organizer, $key, 1 );
+		add_post_meta( $event_id, Tribe__CLI__Meta_Keys::$generated_meta_key, 1 );
+		add_post_meta( $venue, Tribe__CLI__Meta_Keys::$generated_meta_key, 1 );
+		add_post_meta( $organizer, Tribe__CLI__Meta_Keys::$generated_meta_key, 1 );
 
 		return $event_id;
 

--- a/src/Events/Generator/CLI.php
+++ b/src/Events/Generator/CLI.php
@@ -72,13 +72,20 @@ class Tribe__CLI__Events__Generator__CLI extends \WP_CLI_Command {
 	/**
 	 * Reset all TEC event data.
 	 *
+	 * @synopsis   [--all]
 	 * @subcommand reset
 	 */
 	public function reset( $args, $assoc_args ) {
+		$options = [];
 
-		$this->delete_posts( Tribe__Events__Main::POSTTYPE );
-		$this->delete_posts( Tribe__Events__Main::VENUE_POST_TYPE );
-		$this->delete_posts( Tribe__Events__Main::ORGANIZER_POST_TYPE );
+		if ( ! isset( $assoc_args['all'] ) ) {
+			$options['meta_key'] = '_tribe_cli_generated';
+			$options['meta_value'] = 1;
+		}
+
+		$this->delete_posts( Tribe__Events__Main::POSTTYPE, $options );
+		$this->delete_posts( Tribe__Events__Main::VENUE_POST_TYPE, $options );
+		$this->delete_posts( Tribe__Events__Main::ORGANIZER_POST_TYPE, $options );
 
 	}
 
@@ -86,8 +93,9 @@ class Tribe__CLI__Events__Generator__CLI extends \WP_CLI_Command {
 	 * Delete posts for a post type.
 	 *
 	 * @param string $post_type
+	 * @param array $options
 	 */
-	protected function delete_posts( $post_type ) {
+	protected function delete_posts( $post_type, $options = [] ) {
 
 		$counter = 0;
 
@@ -98,6 +106,8 @@ class Tribe__CLI__Events__Generator__CLI extends \WP_CLI_Command {
 			'paged'          => 1,
 			'fields'         => 'ids',
 		);
+
+		$args = array_merge( $args, $options );
 
 		$post_type_obj = get_post_type_object( $post_type );
 

--- a/src/Events/Generator/CLI.php
+++ b/src/Events/Generator/CLI.php
@@ -76,19 +76,16 @@ class Tribe__CLI__Events__Generator__CLI extends \WP_CLI_Command {
 	 * @subcommand reset
 	 */
 	public function reset( $args, $assoc_args ) {
-		global $tribe_cli_container;
-
 		$options = [];
 
 		if ( ! isset( $assoc_args['all'] ) ) {
-			$options['meta_key'] = $tribe_cli_container->getVar( 'generated-meta-key' );
+			$options['meta_key'] = Tribe__CLI__Meta_Keys::$generated_meta_key;
 			$options['meta_value'] = 1;
 		}
 
 		$this->delete_posts( Tribe__Events__Main::POSTTYPE, $options );
 		$this->delete_posts( Tribe__Events__Main::VENUE_POST_TYPE, $options );
 		$this->delete_posts( Tribe__Events__Main::ORGANIZER_POST_TYPE, $options );
-
 	}
 
 	/**

--- a/src/Events/Generator/CLI.php
+++ b/src/Events/Generator/CLI.php
@@ -76,10 +76,12 @@ class Tribe__CLI__Events__Generator__CLI extends \WP_CLI_Command {
 	 * @subcommand reset
 	 */
 	public function reset( $args, $assoc_args ) {
+		global $tribe_cli_container;
+
 		$options = [];
 
 		if ( ! isset( $assoc_args['all'] ) ) {
-			$options['meta_key'] = '_tribe_cli_generated';
+			$options['meta_key'] = $tribe_cli_container->getVar( 'generated-meta-key' );
 			$options['meta_value'] = 1;
 		}
 

--- a/src/Meta_Keys.php
+++ b/src/Meta_Keys.php
@@ -1,0 +1,10 @@
+<?php
+
+class Tribe__Cli__Meta_keys {
+	/**
+	 * meta key used to track CLI generated posts
+	 *
+	 * @var string
+	 */
+	public static $generated_meta_key = '_tribe_cli_generated';
+}

--- a/src/Tickets/Generator/RSVP/CLI.php
+++ b/src/Tickets/Generator/RSVP/CLI.php
@@ -3,6 +3,8 @@
 class Tribe__CLI__Tickets__Generator__RSVP__CLI {
 
 	public function generate_attendees( array $args = null, array $assoc_args = null ) {
+		global $tribe_cli_container;
+
 		$post_id = $args[0];
 		$post    = get_post( absint( $post_id ) );
 
@@ -98,17 +100,17 @@ class Tribe__CLI__Tickets__Generator__RSVP__CLI {
 				$order_id = md5( time() . rand() );
 
 				$meta = array(
-					Tribe__Tickets__RSVP::ATTENDEE_PRODUCT_KEY => $ticket_id,
-					Tribe__Tickets__RSVP::ATTENDEE_EVENT_KEY   => $post_id,
-					Tribe__Tickets__RSVP::ATTENDEE_RSVP_KEY    => $rsvp_status,
-					$tickets->security_code                    => $tickets->generate_security_code( $attendee_id ),
-					$tickets->order_key                        => $order_id,
-					Tribe__Tickets__RSVP::ATTENDEE_OPTOUT_KEY  => '',
-					$tickets->full_name                        => $attendee_name,
-					$tickets->email                            => $attendee_email,
-					'_tribe_tickets_attendee_user_id'          => 0,
-					'_tribe_rsvp_attendee_ticket_sent'         => 1,
-					'_tribe_cli_generated'                     => 1,
+					Tribe__Tickets__RSVP::ATTENDEE_PRODUCT_KEY           => $ticket_id,
+					Tribe__Tickets__RSVP::ATTENDEE_EVENT_KEY             => $post_id,
+					Tribe__Tickets__RSVP::ATTENDEE_RSVP_KEY              => $rsvp_status,
+					$tickets->security_code                              => $tickets->generate_security_code( $attendee_id ),
+					$tickets->order_key                                  => $order_id,
+					Tribe__Tickets__RSVP::ATTENDEE_OPTOUT_KEY            => '',
+					$tickets->full_name                                  => $attendee_name,
+					$tickets->email                                      => $attendee_email,
+					'_tribe_tickets_attendee_user_id'                    => 0,
+					'_tribe_rsvp_attendee_ticket_sent'                   => 1,
+					$tribe_cli_container->getVar( 'generated-meta-key' ) => 1,
 				);
 
 				foreach ( $meta as $key => $value ) {

--- a/src/Tickets/Generator/RSVP/CLI.php
+++ b/src/Tickets/Generator/RSVP/CLI.php
@@ -108,6 +108,7 @@ class Tribe__CLI__Tickets__Generator__RSVP__CLI {
 					$tickets->email                            => $attendee_email,
 					'_tribe_tickets_attendee_user_id'          => 0,
 					'_tribe_rsvp_attendee_ticket_sent'         => 1,
+					'_tribe_cli_generated'                     => 1,
 				);
 
 				foreach ( $meta as $key => $value ) {

--- a/src/Tickets/Generator/RSVP/CLI.php
+++ b/src/Tickets/Generator/RSVP/CLI.php
@@ -3,8 +3,6 @@
 class Tribe__CLI__Tickets__Generator__RSVP__CLI {
 
 	public function generate_attendees( array $args = null, array $assoc_args = null ) {
-		global $tribe_cli_container;
-
 		$post_id = $args[0];
 		$post    = get_post( absint( $post_id ) );
 
@@ -100,17 +98,17 @@ class Tribe__CLI__Tickets__Generator__RSVP__CLI {
 				$order_id = md5( time() . rand() );
 
 				$meta = array(
-					Tribe__Tickets__RSVP::ATTENDEE_PRODUCT_KEY           => $ticket_id,
-					Tribe__Tickets__RSVP::ATTENDEE_EVENT_KEY             => $post_id,
-					Tribe__Tickets__RSVP::ATTENDEE_RSVP_KEY              => $rsvp_status,
-					$tickets->security_code                              => $tickets->generate_security_code( $attendee_id ),
-					$tickets->order_key                                  => $order_id,
-					Tribe__Tickets__RSVP::ATTENDEE_OPTOUT_KEY            => '',
-					$tickets->full_name                                  => $attendee_name,
-					$tickets->email                                      => $attendee_email,
-					'_tribe_tickets_attendee_user_id'                    => 0,
-					'_tribe_rsvp_attendee_ticket_sent'                   => 1,
-					$tribe_cli_container->getVar( 'generated-meta-key' ) => 1,
+					Tribe__Tickets__RSVP::ATTENDEE_PRODUCT_KEY => $ticket_id,
+					Tribe__Tickets__RSVP::ATTENDEE_EVENT_KEY   => $post_id,
+					Tribe__Tickets__RSVP::ATTENDEE_RSVP_KEY    => $rsvp_status,
+					$tickets->security_code                    => $tickets->generate_security_code( $attendee_id ),
+					$tickets->order_key                        => $order_id,
+					Tribe__Tickets__RSVP::ATTENDEE_OPTOUT_KEY  => '',
+					$tickets->full_name                        => $attendee_name,
+					$tickets->email                            => $attendee_email,
+					'_tribe_tickets_attendee_user_id'          => 0,
+					'_tribe_rsvp_attendee_ticket_sent'         => 1,
+					Tribe__CLI__Meta_Keys::$generated_meta_key => 1,
 				);
 
 				foreach ( $meta as $key => $value ) {

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -37,8 +37,13 @@ if ( version_compare( PHP_VERSION, '5.3.0', ">=" ) ) {
 	include dirname( __FILE__ ) . '/vendor/autoload_52.php';
 }
 
-$container = new tad_DI52_Container();
+global $tribe_cli_container;
 
-$container->register( 'Tribe__CLI__Main' );
-$container->register( 'Tribe__CLI__Service_Providers__Events' );
-$container->register( 'Tribe__CLI__Service_Providers__Tickets' );
+$tribe_cli_container = new tad_DI52_Container();
+
+// meta key used to track CLI generated posts
+$tribe_cli_container->setVar( 'generated-meta-key', '_tribe_cli_generated' );
+
+$tribe_cli_container->register( 'Tribe__CLI__Main' );
+$tribe_cli_container->register( 'Tribe__CLI__Service_Providers__Events' );
+$tribe_cli_container->register( 'Tribe__CLI__Service_Providers__Tickets' );

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -37,13 +37,8 @@ if ( version_compare( PHP_VERSION, '5.3.0', ">=" ) ) {
 	include dirname( __FILE__ ) . '/vendor/autoload_52.php';
 }
 
-global $tribe_cli_container;
+$container = new tad_DI52_Container();
 
-$tribe_cli_container = new tad_DI52_Container();
-
-// meta key used to track CLI generated posts
-$tribe_cli_container->setVar( 'generated-meta-key', '_tribe_cli_generated' );
-
-$tribe_cli_container->register( 'Tribe__CLI__Main' );
-$tribe_cli_container->register( 'Tribe__CLI__Service_Providers__Events' );
-$tribe_cli_container->register( 'Tribe__CLI__Service_Providers__Tickets' );
+$container->register( 'Tribe__CLI__Main' );
+$container->register( 'Tribe__CLI__Service_Providers__Events' );
+$container->register( 'Tribe__CLI__Service_Providers__Tickets' );


### PR DESCRIPTION
Reset (for events, venues, and organizers) will now only delete generated posts. If you specify `--all`, it'll clear both generated and non generated alike.