### PR TITLE
Ensure ep_integrate is disabled for delete_posts()

### DIFF
--- a/src/Events/Generator/CLI.php
+++ b/src/Events/Generator/CLI.php
@@ -117,6 +117,7 @@ class Tribe__Cli__Events__Generator__CLI extends WP_CLI_Command {
 			'posts_per_page' => 1,
 			'paged'          => 1,
 			'fields'         => 'ids',
+			'ep_integrate'   => false, // Force ep_integrate to off
 		);
 
 		$args = array_merge( $args, $options );


### PR DESCRIPTION
Prevents potential problems with WP_Query auto integration for ep_integrate