### PR TITLE
Fix typos and a lexer issue

### DIFF
--- a/src/Events/Generator/CLI.php
+++ b/src/Events/Generator/CLI.php
@@ -27,10 +27,10 @@ class Tribe__Cli__Events__Generator__CLI extends WP_CLI_Command {
 	/**
 	 * Generate events 100 at a time (default generates one).
 	 *
-	 * @since 0.1.0
-	 *
 	 * @synopsis   [--count=<count>]
 	 * @subcommand generate
+	 *
+	 * @since 0.1.0
 	 */
 	public function generate( $args, $assoc_args ) {
 
@@ -81,10 +81,10 @@ class Tribe__Cli__Events__Generator__CLI extends WP_CLI_Command {
 	/**
 	 * Reset all TEC event data.
 	 *
-	 * @since 0.1.0
-	 *
 	 * @synopsis   [--all]
 	 * @subcommand reset
+	 *
+	 * @since 0.1.0
 	 */
 	public function reset( $args, $assoc_args ) {
 		$options = [];

--- a/src/Tickets/Command.php
+++ b/src/Tickets/Command.php
@@ -27,8 +27,6 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 	/**
 	 * Generates RSVP attendees for a ticketed post.
 	 *
-	 * @since 0.1.0
-	 *
 	 * ## OPTIONS
 	 *
 	 * <post_id>
@@ -73,6 +71,8 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 	 *      wp event-tickets generate-attendees 23 --ticket_id=89
 	 *
 	 * @subcommand generate-rsvp-attendees
+	 *
+	 * @since 0.1.0
 	 */
 	public function generate_rsvp_attendees( array $args = null, array $assoc_args = null ) {
 		$this->rsvp->generate_attendees( $args, $assoc_args );
@@ -80,8 +80,6 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 
 	/**
 	 * Removes all the RSVP attendees from a ticketed post.
-	 *
-	 * @since 0.1.0
 	 *
 	 * ## OPTIONS
 	 *
@@ -97,6 +95,8 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 	 *      wp event-tickets reset-rsvp-attendees 23 --ticket_id=89
 	 *
 	 * @subcommand reset-rsvp-attendees
+	 *
+	 * @since 0.1.0
 	 */
 	public function reset_rsvp_attendees( array $args = null, array $assoc_args = null ) {
 		$this->rsvp->reset_attendees( $args, $assoc_args );

--- a/src/Tickets_Plus/Command.php
+++ b/src/Tickets_Plus/Command.php
@@ -27,8 +27,6 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 	/**
 	 * Generates WooCommerce orders for a WooCommerce ticketed post.
 	 *
-	 * @since 0.1.0
-	 *
 	 * ## OPTIONS
 	 *
 	 * <post_id>
@@ -80,6 +78,8 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 	 *      wp event-tickets-plus generate-wc-orders 23 --ticket_id=89 --create_users=no
 	 *
 	 * @subcommand generate-wc-orders
+	 *
+	 * @since 0.1.0
 	 */
 	public function generate_wc_orders( array $args = null, array $assoc_args = null ) {
 		$this->wc_generator->generate_orders( $args, $assoc_args );
@@ -87,8 +87,6 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 
 	/**
 	 * Removes all WC orders from a WooCommerce ticketed post.
-	 *
-	 * @since 0.1.0
 	 *
 	 * ## OPTIONS
 	 *
@@ -104,6 +102,8 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 	 *      wp event-tickets-plus reset-wc-orders 23 --ticket_id=89
 	 *
 	 * @subcommand reset-wc-orders
+	 *
+	 * @since 0.1.0
 	 */
 	public function reset_wc_orders( array $args = null, array $assoc_args = null ) {
 		$this->wc_generator->reset_orders( $args, $assoc_args );

--- a/src/Tickets_Plus/Command.php
+++ b/src/Tickets_Plus/Command.php
@@ -71,13 +71,13 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *      wp event-tickets-plus generate-orders 23
-	 *      wp event-tickets-plus generate-orders 23 --count=89
-	 *      wp event-tickets-plus generate-orders 23 --tickets_min=3
-	 *      wp event-tickets-plus generate-orders 23 --tickets_min=3 --tickets_max=10
-	 *      wp event-tickets-plus generate-orders 23 --tickets_min=3 --tickets_max=10 --ticket_status=no
-	 *      wp event-tickets-plus generate-orders 23 --ticket_id=89
-	 *      wp event-tickets-plus generate-orders 23 --ticket_id=89 --create_users=no
+	 *      wp event-tickets-plus generate-wc-orders 23
+	 *      wp event-tickets-plus generate-wc-orders 23 --count=89
+	 *      wp event-tickets-plus generate-wc-orders 23 --tickets_min=3
+	 *      wp event-tickets-plus generate-wc-orders 23 --tickets_min=3 --tickets_max=10
+	 *      wp event-tickets-plus generate-wc-orders 23 --tickets_min=3 --tickets_max=10 --ticket_status=no
+	 *      wp event-tickets-plus generate-wc-orders 23 --ticket_id=89
+	 *      wp event-tickets-plus generate-wc-orders 23 --ticket_id=89 --create_users=no
 	 *
 	 * @subcommand generate-wc-orders
 	 */

--- a/src/Tickets_Plus/Command.php
+++ b/src/Tickets_Plus/Command.php
@@ -67,7 +67,7 @@ class Tribe__Cli__Tickets_Plus__Command extends WP_CLI_Command {
 	 * : the ID of the ticket orders should be assigned to
 	 *
 	 * [--no_create_users]
-	 * : use available subscribers to make orderd and avoid creating users
+	 * : use available subscribers to make orders and avoid creating users
 	 *
 	 * ## EXAMPLES
 	 *


### PR DESCRIPTION
wp-cli synopsis parser wiln not parse if the doc block does not follow the structure exactly, hence I've moved the `@since` tags down to avoid triggering the issue.
Plus some typos.