### PR TITLE
Wait until plugins loaded to init | spotfix

### DIFF
--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -37,9 +37,11 @@ if ( version_compare( PHP_VERSION, '5.3.0', ">=" ) ) {
 	include dirname( __FILE__ ) . '/vendor/autoload_52.php';
 }
 
-$container = new tad_DI52_Container();
+add_action( 'plugins_loaded', function() {
+	$container = new tad_DI52_Container();
 
-$container->register( 'Tribe__Cli__Main' );
-$container->register( 'Tribe__Cli__Service_Providers__Events' );
-$container->register( 'Tribe__Cli__Service_Providers__Tickets' );
-$container->register( 'Tribe__Cli__Service_Providers__Tickets_Plus' );
+	$container->register( 'Tribe__Cli__Main' );
+	$container->register( 'Tribe__Cli__Service_Providers__Events' );
+	$container->register( 'Tribe__Cli__Service_Providers__Tickets' );
+	$container->register( 'Tribe__Cli__Service_Providers__Tickets_Plus' );
+} );

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -37,11 +37,13 @@ if ( version_compare( PHP_VERSION, '5.3.0', ">=" ) ) {
 	include dirname( __FILE__ ) . '/vendor/autoload_52.php';
 }
 
-add_action( 'plugins_loaded', function() {
+function tribe_cli_init() {
 	$container = new tad_DI52_Container();
 
 	$container->register( 'Tribe__Cli__Main' );
 	$container->register( 'Tribe__Cli__Service_Providers__Events' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets_Plus' );
-} );
+}
+
+add_action( 'plugins_loaded', 'tribe_cli_init' );


### PR DESCRIPTION
Wait until other plugins have loaded before initializing (avoids warning messages about ET+ etc not being active).