### PR TITLE
add PayPal ticket generation support

### DIFF
--- a/src/Commerce/Command.php
+++ b/src/Commerce/Command.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Class Tribe__Cli__Commerce__Command
+ *
+ * @since 0.1.0
+ */
+class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
+
+	/**
+	 * @var \Tribe__Cli__Commerce__Generator__PayPal__CLI
+	 */
+	protected $paypal;
+
+	/**
+	 * Tribe__CLI__Commerce__Command constructor.
+	 *
+	 * @since 0.1.0
+	 *
+	 * @param \Tribe__Cli__Tickets__Generator__RSVP__CLI $paypal
+	 */
+	public function __construct( Tribe__Cli__Commerce__Generator__PayPal__CLI $paypal ) {
+		parent::__construct();
+		$this->paypal = $paypal;
+	}
+
+	/**
+	 * Generates PayPal orders for a ticketed post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : PayPal orders will be attached to this post
+	 *
+	 * [--count=<count>]
+	 * : the number of PayPal orders to generate
+	 * ---
+	 * default: 10
+	 * ---
+	 *
+	 * [--attendees_min=<attendees_min>]
+	 * : the minimum number of attendees per PayPal order
+	 * ---
+	 * default: 1
+	 * ---
+	 *
+	 * [--attendees_max=<attendees_max>]
+	 * : the maximum number of attendees per PayPal order
+	 * ---
+	 * default: 3
+	 * ---
+	 *
+	 * [--order_status=<order_status>]
+	 * : the status of the PayPal orders
+	 * ---
+	 * default: completed
+	 * options:
+	 *      - completed
+	 *      - pending
+	 *      - denied
+	 *      - refunded
+	 * ---
+	 *
+	 * [--ticket_id=<ticket_id>]
+	 * : the ID of the ticket PayPal orders should be generated for
+	 *
+	 * ## EXAMPLES
+	 *
+	 *      wp commerce generate-paypal-orders 23
+	 *      wp commerce generate-paypal-orders 23 --count=89
+	 *      wp commerce generate-paypal-orders 23 --attendees_min=3
+	 *      wp commerce generate-paypal-orders 23 --attendees_min=3 --attendees_max=10
+	 *      wp commerce generate-paypal-orders 23 --attendees_min=3 --attendees_max=10 --order_status=denied
+	 *      wp commerce generate-paypal-orders 23 --ticket_id=89
+	 *
+	 * @subcommand generate-paypal-orders
+	 *
+	 * @since 0.1.0
+	 */
+	public function generate_paypal_orders( array $args = null, array $assoc_args = null ) {
+		$this->paypal->generate_orders( $args, $assoc_args );
+	}
+}

--- a/src/Commerce/Command.php
+++ b/src/Commerce/Command.php
@@ -75,9 +75,31 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	 *
 	 * @subcommand generate-paypal-orders
 	 *
-	 * @since 0.1.0
+	 * @since TBD
+	 *
 	 */
 	public function generate_paypal_orders( array $args = null, array $assoc_args = null ) {
 		$this->paypal->generate_orders( $args, $assoc_args );
+	}
+
+	/**
+	 * Removes generated PayPal orders from a ticketed post.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <post_id>
+	 * : PayPal orders will be removed from this post
+	 *
+	 * ## EXAMPLES
+	 *
+	 *      wp commerce reset-paypal-orders 23
+	 *
+	 * @subcommand reset-paypal-orders
+	 *
+	 * @since TBD
+	 *
+	 */
+	public function reset_paypal_orders(  array $args = null, array $assoc_args = null  ) {
+		$this->paypal->reset_orders( $args, $assoc_args );
 	}
 }

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -73,6 +73,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 			$progress->tick();
 
 			$faker = Faker\Factory::create();
+			$faker->addProvider( new Faker\Provider\en_US\Address( $faker ) );
 
 			$transaction_id = strtoupper( substr( md5( $faker->sentence ), 0, 17 ) );
 			$receiver_id    = strtoupper( substr( md5( $faker->sentence ), 0, 13 ) );
@@ -87,7 +88,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 			$data = array(
 				'last_name'              => $faker->lastName,
 				'shipping_method'        => 'Default',
-				'address_state'          => 'CA',
+				'address_state'          => $faker->stateAbbr,
 				'receiver_email'         => $receiver_email,
 				'custom'                 => '{"user_id":' . $user_id . ',"tribe_handler":"tpp"}',
 				'item_name1'             => "{$ticket->name} - {$post->post_title}",
@@ -97,7 +98,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 				'payer_email'            => $faker->email,
 				'protection_eligibility' => 'Eligible',
 				'item_number1'           => "{$post_id}:{$ticket_id}",
-				'address_zip'            => '95131',
+				'address_zip'            => $faker->postcode,
 				'mc_handling1'           => '0.00',
 				'payment_fee'            => $this->signed_value( 0.09 ),
 				'transaction_subject'    => '',
@@ -112,7 +113,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 				'verify_sign'            => 'Au138tmgDC7.8B8qKvd-30AoY8IgAFfYkrYMbXOdLJmWDmKOip2XAIyQ',
 				'mc_shipping1'           => '0.00',
 				'business'               => $receiver_email,
-				'address_city'           => 'San Jose',
+				'address_city'           => $faker->city,
 				'first_name'             => $faker->firstName,
 				'address_name'           => $faker->name,
 				'mc_shipping'            => '0.00',
@@ -122,7 +123,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 				'ipn_track_id'           => $ipn_track_id,
 				'payment_gross'          => $this->signed_value( $payment_gross ),
 				'address_country_code'   => 'US',
-				'address_street'         => '1 Main St',
+				'address_street'         => $faker->streetAddress,
 				'payment_type'           => 'instant',
 				'payer_id'               => $payer_id,
 				'quantity1'              => $ticket_qty,

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -1,0 +1,314 @@
+<?php
+
+use function WP_CLI\Utils\format_items;
+use function WP_CLI\Utils\make_progress_bar;
+
+class Tribe__Cli__Commerce__Generator__PayPal__CLI {
+
+	protected $order_status;
+
+	public function generate_orders( array $args, array $assoc_args = array() ) {
+		$post_id = $this->parse_post_id( $args );
+
+		/** @var \Tribe__Tickets__Commerce__PayPal__Main $paypal */
+		$paypal = tribe( 'tickets.commerce.paypal' );
+
+		$ticket_ids = $this->parse_ticket_ids( $assoc_args, $post_id );
+
+		list( $tickets_min, $tickets_max ) = $this->parse_attendees_min_max( $assoc_args );
+
+		$orders_count = $this->parse_count( $assoc_args );
+		$order_status = $this->parse_order_status( $assoc_args );
+		$post         = get_post( $post_id );
+
+		WP_CLI::log( "Generating PayPal {$orders_count} orders for post {$post_id}" );
+
+		$progress  = make_progress_bar( 'Generating orders', $orders_count );
+		$generated = array();
+
+		$this->hijack_request_flow();
+
+		for ( $k = 0; $k < $orders_count; $k ++ ) {
+			$user_id   = 0;
+			$ticket_id = $ticket_ids[ array_rand( $ticket_ids, 1 ) ];
+			$ticket    = $paypal->get_ticket( $post_id, $ticket_id );
+
+			$this->backup_ticket_total_sales( $ticket_id );
+
+			$ticket_qty = mt_rand( $tickets_min, $tickets_max );
+
+			$inventory  = $ticket->inventory();
+			$inventory  = - 1 === $inventory ? 'unlimited' : $inventory;
+			$ticket_qty = 'unlimited' === $inventory ? $ticket_qty : min( $ticket_qty, (int) $inventory );
+
+			WP_CLI::log( "Generating an order for {$ticket_qty} attendees for ticket {$ticket_id}, current ticket inventory is {$inventory}" );
+
+			if ( $ticket_qty === 0 ) {
+				WP_CLI::log( "Not generating attendees for ticket {$ticket_id} as it ran out of inventory" );
+				continue;
+			}
+
+			$this->order_status = $order_status;
+
+			$progress->tick();
+
+			$faker = Faker\Factory::create();
+
+			$transaction_id = strtoupper( substr( md5( $faker->sentence ), 0, 17 ) );
+			$receiver_id    = strtoupper( substr( md5( $faker->sentence ), 0, 13 ) );
+			$payer_id       = strtoupper( substr( md5( $faker->sentence ), 0, 13 ) );
+			$ipn_track_id   = substr( md5( $faker->sentence ), 0, 13 );
+
+			$ticket_price   = $ticket->price;
+			$payment_gross  = $ticket_price * $ticket_qty;
+			$receiver_email = 'merchant@' . parse_url( home_url(), PHP_URL_HOST );
+			$payment_date   = $faker->date( 'H:i:s M d, Y e' );
+
+			$data = array(
+				'last_name'              => $faker->lastName,
+				'shipping_method'        => 'Default',
+				'address_state'          => 'CA',
+				'receiver_email'         => $receiver_email,
+				'custom'                 => '{"user_id":' . $user_id . ',"tribe_handler":"tpp"}',
+				'item_name1'             => "{$ticket->name} - {$post->post_title}",
+				'shipping_discount'      => '0.00',
+				'receiver_id'            => $receiver_id,
+				'charset'                => 'windows-1252',
+				'payer_email'            => $faker->email,
+				'protection_eligibility' => 'Eligible',
+				'item_number1'           => "{$post_id}:{$ticket_id}",
+				'address_zip'            => '95131',
+				'mc_handling1'           => '0.00',
+				'payment_fee'            => $this->signed_value( 0.09 ),
+				'transaction_subject'    => '',
+				'txn_id'                 => $transaction_id,
+				'residence_country'      => 'US',
+				'payment_status'         => ucwords( $order_status ),
+				'mc_fee'                 => $this->signed_value( 0.09 ),
+				'mc_gross'               => $this->signed_value( $payment_gross ),
+				'insurance_amount'       => '0.00',
+				'address_country'        => 'United States',
+				'mc_currency'            => 'USD',
+				'verify_sign'            => 'Au138tmgDC7.8B8qKvd-30AoY8IgAFfYkrYMbXOdLJmWDmKOip2XAIyQ',
+				'mc_shipping1'           => '0.00',
+				'business'               => $receiver_email,
+				'address_city'           => 'San Jose',
+				'first_name'             => $faker->firstName,
+				'address_name'           => $faker->name,
+				'mc_shipping'            => '0.00',
+				'notify_version'         => '3.8',
+				'mc_gross_1'             => $payment_gross,
+				'test_ipn'               => '1',
+				'ipn_track_id'           => $ipn_track_id,
+				'payment_gross'          => $this->signed_value( $payment_gross ),
+				'address_country_code'   => 'US',
+				'address_street'         => '1 Main St',
+				'payment_type'           => 'instant',
+				'payer_id'               => $payer_id,
+				'quantity1'              => $ticket_qty,
+				'discount'               => '0.00',
+				'payment_date'           => $payment_date,
+				'mc_handling'            => '0.00',
+				'tax1'                   => '0.00',
+			);
+
+			if ( $order_status === Tribe__Tickets__Commerce__PayPal__Stati::$refunded ) {
+				// complete the order to be refunded before the refund
+				$data['payment_status'] = ucwords( Tribe__Tickets__Commerce__PayPal__Stati::$completed );
+				$this->order_status     = Tribe__Tickets__Commerce__PayPal__Stati::$completed;
+				$this->update_fees( $data );
+				$this->generate_tickets( Tribe__Tickets__Commerce__PayPal__Stati::$completed, $data );
+
+				$data['payment_status'] = ucwords( Tribe__Tickets__Commerce__PayPal__Stati::$refunded );
+				$this->order_status     = Tribe__Tickets__Commerce__PayPal__Stati::$refunded;
+				$this->update_fees( $data );
+				$data['reason_code']   = 'refund';
+				$data['parent_txn_id'] = $transaction_id;
+				$data['txn_id']        = strtoupper( substr( md5( $faker->sentence ), 0, 17 ) );
+			}
+
+			$this->generate_tickets( $order_status, $data );
+
+			$generated[] = array(
+				'Order ID'        => $transaction_id,
+				'Attendees count' => $ticket_qty,
+			);
+		}
+
+		$progress->finish();
+		WP_CLI::success( "Generated {$orders_count} orders for post {$post_id}" );
+		format_items( 'table', $generated, array( 'Order ID', 'Attendees count' ) );
+	}
+
+	/**
+	 * @param array $args
+	 *
+	 * @return int
+	 * @throws \WP_CLI\ExitException
+	 */
+	protected function parse_post_id( array $args ) {
+		$post_id = (int) $args[0];
+		$post    = get_post( $post_id );
+
+		if ( empty( $post ) ) {
+			WP_CLI::error( "There is no post with an ID of {$post_id}" );
+		}
+
+		// willingly let orders be created for posts on which Tickets might not be enabled
+		// but avoid nonsense
+		$forbidden_post_types = array(
+			Tribe__Tickets__Commerce__PayPal__Main::ATTENDEE_OBJECT,
+		);
+
+		if ( in_array( $post->post_type, $forbidden_post_types ) ) {
+			WP_CLI::error( "You cannot create PayPal orders for posts of the {$post->post_type} type" );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * @param array $assoc_args
+	 * @param       $paypal
+	 * @param       $post_id
+	 *
+	 * @return array
+	 * @throws \WP_CLI\ExitException
+	 */
+	protected function parse_ticket_ids( array $assoc_args, $post_id ) {
+		/** @var \Tribe__Tickets__Commerce__PayPal__Main $paypal */
+		$paypal     = tribe( 'tickets.commerce.paypal' );
+		$ticket_ids = $paypal->get_tickets_ids( $post_id );
+
+		if ( ! isset( $assoc_args['ticket_id'] ) ) {
+		} else {
+			$ticket_post = get_post( $assoc_args['ticket_id'] );
+
+			if ( empty( $ticket_post ) || $paypal->ticket_object !== $ticket_post->post_type || ! in_array( $ticket_post->ID, $ticket_ids ) ) {
+				WP_CLI::error( 'The provided ticket ID is either not valid or not a PayPal ticket ID' );
+			}
+
+			$ticket_ids = array( $ticket_post->ID );
+		}
+
+		return $ticket_ids;
+	}
+
+	protected function parse_attendees_min_max( array $assoc_args ) {
+		if ( ! (
+				filter_var( $assoc_args['attendees_min'], FILTER_VALIDATE_INT )
+				&& filter_var( $assoc_args['attendees_max'], FILTER_VALIDATE_INT )
+			)
+		     || (int) $assoc_args['attendees_min'] > $assoc_args['attendees_max']
+		     || 0 > $assoc_args['attendees_min']
+		     || 0 > $assoc_args['attendees_max']
+		) {
+			WP_CLI::error( 'Attendees min and max should be positive integers that make sense' );
+		}
+
+		return array( (int) $assoc_args['attendees_min'], $assoc_args['attendees_max'] );
+	}
+
+	/**
+	 * @param array $assoc_args
+	 *
+	 * @throws \WP_CLI\ExitException
+	 */
+	protected function parse_count( array $assoc_args ) {
+		if ( ! filter_var( $assoc_args['count'], FILTER_VALIDATE_INT ) || (int) $assoc_args['count'] < 1 ) {
+			WP_CLI::error( 'The count parameter should be a positive integer' );
+		}
+
+		return (int) $assoc_args['count'];
+	}
+
+	protected function parse_order_status( array $assoc_args ) {
+		$order_status = trim( $assoc_args['order_status'] );
+
+		$supported_stati = array(
+			Tribe__Tickets__Commerce__PayPal__Stati::$completed,
+			Tribe__Tickets__Commerce__PayPal__Stati::$pending,
+			Tribe__Tickets__Commerce__PayPal__Stati::$refunded,
+			Tribe__Tickets__Commerce__PayPal__Stati::$denied,
+		);
+
+		if ( ! in_array( $order_status, $supported_stati ) ) {
+			WP_CLI::error( "The {$order_status} order status is not valid or suported" );
+		}
+
+		return $order_status;
+	}
+
+	/**
+	 * @param $ticket_id
+	 */
+	protected function backup_ticket_total_sales( $ticket_id ) {
+		$backup_key        = Tribe__Cli__Meta_Keys::$total_sales_backup_meta_key;
+		$saved_total_sales = get_post_meta( $ticket_id, $backup_key, true );
+		if ( '' === $saved_total_sales ) {
+			update_post_meta( $ticket_id, $backup_key, get_post_meta( $ticket_id, 'total_sales', true ) );
+		}
+	}
+
+	protected function signed_value( $fee ) {
+		if ( Tribe__Tickets__Commerce__PayPal__Stati::$refunded === $this->order_status ) {
+			return '-' . $fee;
+		}
+
+		return '' . $fee;
+	}
+
+	protected function update_fees( array $data ) {
+		$fee_fields = array(
+			'payment_fee',
+			'mc_fee',
+			'mc_gross',
+			'payment_gross',
+		);
+
+		foreach ( $fee_fields as $field ) {
+			if ( ! isset( $data[ $field ] ) ) {
+				continue;
+			}
+
+			$data[ $field ] = $this->signed_value( abs( (float) $data[ $field ] ) );
+		}
+
+		return $data;
+	}
+
+	/**
+	 * @param $gateway
+	 * @param $transaction_data
+	 * @param $paypal
+	 * @param $order_status
+	 */
+	protected function generate_tickets( $order_status, $transaction_data ) {
+		/** @var \Tribe__Tickets__Commerce__PayPal__Main $paypal */
+		$paypal = tribe( 'tickets.commerce.paypal' );
+
+		/** @var \Tribe__Tickets__Commerce__PayPal__Gateway $gateway */
+		$gateway = tribe( 'tickets.commerce.paypal.gateway' );
+
+		$fake_transaction_data = $gateway->parse_transaction( $transaction_data );
+
+		add_filter( 'tribe_tickets_commerce_paypal_get_transaction_data', function () use ( $fake_transaction_data ) {
+			return $fake_transaction_data;
+		} );
+
+
+		$paypal->generate_tickets( $order_status, false );
+	}
+
+	protected function hijack_request_flow() {
+		add_action( 'event_tickets_tpp_attendee_created', function ( $attendee_id ) {
+			update_post_meta( $attendee_id, Tribe__Cli__Meta_Keys::$generated_meta_key, 1 );
+		} );
+
+		add_filter( 'tribe_tickets_tpp_send_mail', '__return_false' );
+
+		add_filter( 'tribe_exit', function () {
+			return '__return_true';
+		} );
+	}
+}

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -8,7 +8,7 @@ use function WP_CLI\Utils\make_progress_bar;
 /**
  * Class Tribe__Cli__Commerce__Generator__PayPal__CLI
  *
- * @since TBD
+ * @since 0.2.0
  */
 class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 
@@ -20,7 +20,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Generates the PayPal orders for a post.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -164,7 +164,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Parses, validating it, the user-proviced post ID.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $args
 	 *
@@ -196,7 +196,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Parses, validating and checking it, the user-provided ticket ID.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $assoc_args
 	 * @param int   $post_id
@@ -228,7 +228,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	 * Parses, validating and sanity-checking them, the user-provided
 	 * attendee min and max values.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $assoc_args
 	 *
@@ -254,7 +254,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Parse and validates the user-provided orders count.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $assoc_args
 	 *
@@ -273,7 +273,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Parses and validate the user-provided PayPal order status.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $assoc_args
 	 *
@@ -301,7 +301,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Hijack some PayPal related hooks to make all work.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 */
 	protected function hijack_request_flow() {
 		// all transactions are valid, we are generating fake numbers
@@ -330,7 +330,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Backups the total sales for a ticket before the generation kicks in.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param int $ticket_id
 	 */
@@ -347,7 +347,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	 *
 	 * Some order stati will require a negative value, e.g. refunds.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param int $fee
 	 *
@@ -364,7 +364,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Updates the fees in the data depending on the current order status.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array $data
 	 *
@@ -392,7 +392,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Generate the tickets using the PayPal code API.
 	 *
-	 * @since TBD
+	 * @since 0.2.0
 	 *
 	 * @param array  $transaction_data
 	 * @param string $order_status

--- a/src/Meta_Keys.php
+++ b/src/Meta_Keys.php
@@ -12,5 +12,11 @@ class Tribe__Cli__Meta_Keys {
 	 * @var string
 	 */
 	public static $generated_meta_key = '_tribe_cli_generated';
+
+	/**
+	 * Meta key used to store a backup of the total sales for a commerce related post.
+	 *
+	 * @var string
+	 */
 	public static $total_sales_backup_meta_key = '_tribe_cli_total_sales_backup';
 }

--- a/src/Meta_Keys.php
+++ b/src/Meta_Keys.php
@@ -12,4 +12,5 @@ class Tribe__Cli__Meta_Keys {
 	 * @var string
 	 */
 	public static $generated_meta_key = '_tribe_cli_generated';
+	public static $total_sales_backup_meta_key = '_tribe_cli_total_sales_backup';
 }

--- a/src/Service_Providers/Events.php
+++ b/src/Service_Providers/Events.php
@@ -65,7 +65,7 @@ class Tribe__Cli__Service_Providers__Events extends Tribe__Cli__Service_Provider
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'tribe-events-generator', $this->container->make( 'Tribe__Cli__Events__Generator__CLI' ) );
+			WP_CLI::add_command( 'tribe-events-generator', $this->container->make( 'Tribe__Cli__Events__Generator__CLI' ), array( 'shortdesc' => $this->get_display_name() ) );
 		}
 	}
 }

--- a/src/Service_Providers/Tickets_Plus.php
+++ b/src/Service_Providers/Tickets_Plus.php
@@ -64,7 +64,7 @@ class Tribe__Cli__Service_Providers__Tickets_Plus extends Tribe__Cli__Service_Pr
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'event-tickets-plus', $this->container->make( 'Tribe__Cli__Tickets_Plus__Command' ) );
+			WP_CLI::add_command( 'event-tickets-plus', $this->container->make( 'Tribe__Cli__Tickets_Plus__Command' ), array( 'shortdesc' => $this->get_display_name() ) );
 		}
 
 		// avoid sending emails for fake orders

--- a/src/Service_Providers/Tribe_Commerce.php
+++ b/src/Service_Providers/Tribe_Commerce.php
@@ -1,10 +1,18 @@
 <?php
+
+/**
+ * Class Tribe__Cli__Service_Providers__Tribe_Commerce
+ *
+ * @since 0.2.0
+ */
 class Tribe__Cli__Service_Providers__Tribe_Commerce extends Tribe__Cli__Service_Providers__Base  {
 
 	const REQUIRED_TICKETS_VERSION = '4.7dev';
 
 	/**
 	 * Returns each plugin required by this one to run
+	 *
+	 * @since 0.2.0
 	 *
 	 * @return array {
 	 *      List of required plugins.
@@ -31,6 +39,8 @@ class Tribe__Cli__Service_Providers__Tribe_Commerce extends Tribe__Cli__Service_
 	/**
 	 * Returns the display name of this functionality.
 	 *
+	 * @since 0.2.0
+	 *
 	 * @return string
 	 */
 	protected function get_display_name() {
@@ -39,6 +49,8 @@ class Tribe__Cli__Service_Providers__Tribe_Commerce extends Tribe__Cli__Service_
 
 	/**
 	 * Binds and sets up implementations.
+	 *
+	 * @since 0.2.0
 	 */
 	public function register() {
 		if ( ! $this->should_run() ) {

--- a/src/Service_Providers/Tribe_Commerce.php
+++ b/src/Service_Providers/Tribe_Commerce.php
@@ -1,21 +1,10 @@
 <?php
+class Tribe__Cli__Service_Providers__Tribe_Commerce extends Tribe__Cli__Service_Providers__Base  {
 
-/**
- * Class Tribe__Cli__Service_Providers__Tickets
- *
- * @since 0.1.0
- */
-class Tribe__Cli__Service_Providers__Tickets extends Tribe__Cli__Service_Providers__Base {
-
-	/**
-	 * Minimum required version of Event Tickets
-	 */
-	const REQUIRED_TICKETS_VERSION = '4.5.4';
+	const REQUIRED_TICKETS_VERSION = '4.7dev';
 
 	/**
 	 * Returns each plugin required by this one to run
-	 *
-	 * @since 0.1.0
 	 *
 	 * @return array {
 	 *      List of required plugins.
@@ -30,7 +19,7 @@ class Tribe__Cli__Service_Providers__Tickets extends Tribe__Cli__Service_Provide
 	protected function get_requisite_plugins() {
 		return array(
 			array(
-				'short_name'   => 'Event Tickets',
+				'short_name'   => 'Event Tickets (with Tribe Commerce)',
 				'class'        => 'Tribe__Tickets__Main',
 				'thickbox_url' => 'plugin-install.php?tab=plugin-information&plugin=event-tickets&TB_iframe=true',
 				'min_version'  => self::REQUIRED_TICKETS_VERSION,
@@ -42,18 +31,14 @@ class Tribe__Cli__Service_Providers__Tickets extends Tribe__Cli__Service_Provide
 	/**
 	 * Returns the display name of this functionality.
 	 *
-	 * @since 0.1.0
-	 *
 	 * @return string
 	 */
 	protected function get_display_name() {
-		return 'Event Tickets WP-CLI Tools';
+		return 'Tribe Commerce WP-CLI Tools';
 	}
 
 	/**
 	 * Binds and sets up implementations.
-	 *
-	 * @since 0.1.0
 	 */
 	public function register() {
 		if ( ! $this->should_run() ) {
@@ -64,7 +49,7 @@ class Tribe__Cli__Service_Providers__Tickets extends Tribe__Cli__Service_Provide
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'event-tickets', $this->container->make( 'Tribe__Cli__Tickets__Command' ), array( 'shortdesc' => $this->get_display_name() ) );
+			WP_CLI::add_command( 'commerce', $this->container->make( 'Tribe__Cli__Commerce__Command' ), array('shortdesc' => $this->get_display_name()) );
 		}
 	}
 }

--- a/src/Tickets/Command.php
+++ b/src/Tickets/Command.php
@@ -17,11 +17,11 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 	 *
 	 * @since 0.1.0
 	 *
-	 * @param \Tribe__Cli__Tickets__Generator__RSVP__CLI $rsvp
+	 * @param \Tribe__Cli__Tickets__Generator__RSVP__CLI $paypal
 	 */
-	public function __construct( Tribe__Cli__Tickets__Generator__RSVP__CLI $rsvp ) {
+	public function __construct( Tribe__Cli__Tickets__Generator__RSVP__CLI $paypal ) {
 		parent::__construct();
-		$this->rsvp = $rsvp;
+		$this->rsvp = $paypal;
 	}
 
 	/**
@@ -64,12 +64,12 @@ class Tribe__Cli__Tickets__Command extends WP_CLI_Command {
 	 *
 	 * ## EXAMPLES
 	 *
-	 *      wp event-tickets generate-attendees 23
-	 *      wp event-tickets generate-attendees 23 --count=89
-	 *      wp event-tickets generate-attendees 23 --tickets_min=3
-	 *      wp event-tickets generate-attendees 23 --tickets_min=3 --tickets_max=10
-	 *      wp event-tickets generate-attendees 23 --tickets_min=3 --tickets_max=10 --ticket_status=no
-	 *      wp event-tickets generate-attendees 23 --ticket_id=89
+	 *      wp event-tickets generate-rsvp-attendees 23
+	 *      wp event-tickets generate-rsvp-attendees 23 --count=89
+	 *      wp event-tickets generate-rsvp-attendees 23 --tickets_min=3
+	 *      wp event-tickets generate-rsvp-attendees 23 --tickets_min=3 --tickets_max=10
+	 *      wp event-tickets generate-rsvp-attendees 23 --tickets_min=3 --tickets_max=10 --ticket_status=no
+	 *      wp event-tickets generate-rsvp-attendees 23 --ticket_id=89
 	 *
 	 * @subcommand generate-rsvp-attendees
 	 *

--- a/src/functions/template.php
+++ b/src/functions/template.php
@@ -1,0 +1,8 @@
+<?php
+/**
+ * Templating related functions
+ */
+
+function tribe_cli_template($template,array $data = array()){
+
+};

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -43,7 +43,10 @@ function tribe_cli_init() {
 	$container->register( 'Tribe__Cli__Main' );
 	$container->register( 'Tribe__Cli__Service_Providers__Events' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets' );
+	$container->register( 'Tribe__Cli__Service_Providers__Tribe_Commerce' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets_Plus' );
 }
+
+include_once(dirname(__FILE__) . '/src/functions/template.php');
 
 add_action( 'plugins_loaded', 'tribe_cli_init' );


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/97806

While the "undo" is still missing the biggest functionality is there, will implement the removal of orders in another PR.