### PR TITLE
Extend support for tribe commerce and pending stock

### DIFF
--- a/src/Commerce/Command.php
+++ b/src/Commerce/Command.php
@@ -129,7 +129,7 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	 *
 	 * @subcommand update-paypal-order-status
 	 *
-	 * @since TBD
+	 * @since 0.2.1
 	 *
 	 */
 	public function update_paypal_order_status( array $args = null, array $assoc_args = null ) {

--- a/src/Commerce/Command.php
+++ b/src/Commerce/Command.php
@@ -101,4 +101,38 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	public function reset_paypal_orders(  array $args = null, array $assoc_args = null  ) {
 		$this->paypal->reset_orders( $args, $assoc_args );
 	}
+
+	/**
+	 * Updates the status of a generated PayPal order.
+	 *
+	 * ## OPTIONS
+	 *
+	 * <order_id>
+	 * : the PayPal ID (hash) or post ID of an existing PayPal order.
+	 *
+	 * --order_status=<order_status>
+	 * : the status of the PayPal orders
+	 * ---
+	 * options:
+	 *      - completed
+	 *      - pending
+	 *      - denied
+	 *      - refunded
+	 * ---
+	 *
+	 * ## EXAMPLES
+	 *
+	 *      wp commerce update-paypal-order-status 23 --order_status=completed
+	 *      wp commerce update-paypal-order-status 23 --order_status=pending
+	 *      wp commerce update-paypal-order-status 23 --order_status=denied
+	 *      wp commerce update-paypal-order-status 23 --order_status=refunded
+	 *
+	 * @subcommand update-paypal-order-status
+	 *
+	 * @since TBD
+	 *
+	 */
+	public function update_paypal_order_status( array $args = null, array $assoc_args = null ) {
+		$this->paypal->update_order_status( $args, $assoc_args );
+	}
 }

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -73,7 +73,10 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 
 				$this->backup_ticket_total_sales( $ticket_id );
 
-				$inventory  = $ticket->inventory();
+				add_filter( 'tribe_tickets_tpp_pending_stock_ignore', '__return_true' );
+				$inventory = $ticket->inventory();
+				add_filter( 'tribe_tickets_tpp_pending_stock_ignore', '__return_false' );
+
 				$this_ticket_qty = -1 === $inventory ? $this_ticket_qty : min( $this_ticket_qty, (int) $inventory );
 
 				if ( $this_ticket_qty === 0 ) {

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -399,6 +399,8 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	 * @param string $order_status
 	 */
 	protected function place_order( $order_status, $transaction_data ) {
+		$this->hijack_request_flow();
+
 		/** @var \Tribe__Tickets__Commerce__PayPal__Main $paypal */
 		$paypal = tribe( 'tickets.commerce.paypal' );
 

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -555,7 +555,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Updates the status of an Order.
 	 *
-	 * @since TBD
+	 * @since 0.2.1
 	 *
 	 * @param array $args
 	 * @param array $assoc_args
@@ -600,7 +600,7 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 	/**
 	 * Parses and returns the Order post ID.
 	 *
-	 * @since TBD
+	 * @since 0.2.1
 	 *
 	 * @param array $args
 	 *


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98563

This PR adds the `update-paypal-order-status` command and relieso on modified ET and common code to work.
It also fixes an issue where cleanup would not work as intended.