### PR TITLE
Fix stock and email related issues

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -33,13 +33,11 @@ Note: you'll need to have the latest versions of <a href="http://m.tri.be/3j">Th
 
 = Requirements =
 
-* PHP 5.3.29 or greater (recommended: PHP 5.4 or greater)
+* PHP 5.4.29 or greater (recommended: PHP 7.0 or greater)
 * WordPress 4.5 or above
-* jQuery 1.11.x
-* The Events Calendar 4.5.4 or above
-* Community Events 3.12.1 or above
-* Event Tickets 4.5.4 or above
-* Tickets Plus 4.0 or above
+* The Events Calendar 4.5.4 or above to use The Events Calendar command
+* Event Tickets 4.5.4 or above to use Event Tickets command
+* Tickets Plus 4.0 or above to use Events Tickets Plus command
 
 == Documentation ==
 
@@ -154,95 +152,17 @@ Our Premium Plugins:
 
 == Changelog ==
 
-= [4.4.4] 2017-07-13 =
+= [0.2.1] 2017-01-19 =
 
-* Fix - Added notice when Woo, Community, or Event Tickets is not active [70357]
+* Add support for the `--reset-deleted-attendees` flag to the `reset-paypal-orders` command
+* Add support for the `--dont-send-emails` flag to the `generate-paypal-orders` and `update-paypal-order-status` commands
+* Change default behaviour of generation and update commands to send emails
+* Fix an issue where the ticket `_stock` meta would be screwed up when removing generated orders
 
-= [4.4.3] 2017-06-06 =
+= [0.2.0] 2017-01-19 =
 
-* Tweak - Compatibility with version 4.5 of Community Events
-* Tweak - Added actions: `tribe_events_community_section_before_tickets`, `tribe_events_community_section_after_tickets`
-* Tweak - Removed actions: `tribe_events_community_after_the_tickets`
-* Language - 0 new strings added, 14 updated, 0 fuzzied, and 0 obsoleted [events-generator]
+* Add PayPal ticket generation support
 
-= [4.4.2] 2017-05-17 =
-
-* Tweak - further adjustments made to our plugin licensing system [78506]
-
-= [4.4.1] 2017-05-03 =
-
-* Tweak - adjustments made to our plugin licensing system
-
-= [4.4] 2017-01-09 =
-
-* Tweak - Brings the plugin up-to-date with changes made in Event Tickets [67176, 70431]
-* Tweak - Brings the plugin up-to-date with changes made in Community Events [69762]
-* Tweak - Transitioned the dropdown selectors to the same system used in the parent plugins [69353]
-* Tweak - Text and translation fixes
-
-= [4.3.2] 2016-12-20 =
-
-* Tweak - Updated the template override instructions in a number of templates [68229]
-
-= [4.3.1] 2016-10-20 =
-
-* Tweak - Added plugin file path constant
-* Tweak - Registered plugin as active with Tribe Common [66657]
-
-= [4.3] 2016-10-13 =
-
-* Tweak - Updated to be 4.3 compatible
-
-= [4.2.2] 2016-07-06 =
-
-* Security - Tightened security around event reports
-* Tweak - re-label "PayPal client ID" setting to be "PayPal Application ID" [45120]
-* Tweak - improved integration with Woo in the custom PayPal split payment gateway [44807]
-
-= [4.2.1] 2016-06-22 =
-
-* Tweak - Fixed spacing on Fee Option Defaults tooltip
-
-= [4.2] 2016-06-08 =
-
-* Tweak - Language files in the `wp-content/languages/plugins` path will be loaded before attempting to load internal language files (Thank you to user @aafhhl for bringing this to our attention!)
-* Tweak - Move plugin CSS to PostCSS
-
-= [4.1.1] 2016-05-19 =
-
-* Fix - Default to preventing organizers from deleting tickets when sales have been made
-
-= [4.1] 2016-03-15 =
-
-* Fix - Resolved issue where the "Email Attendees" modal box didn't open in a modal box (mad fist bump to @xlr8r for the heads up!)
-
-= [4.0.4] 2016-03-02 =
-
-* Fix - PayPal payments are fully working again with split payments checkout (HTTP 1.1)
-
-= [4.0.3] 2016-02-17 =
-
-* Fix - Prevents Event Generator to output HTML on the CSV exporting tool
-
-= [4.0.2] 2015-12-16 =
-
-* Fix - Resolved fatals introduced by relocated files in WP 4.4 (Thank you Dirk for reporting this!)
-* Fix - Resolved textdomain issue that caused translations to fail
-
-= [4.0.1] 2015-12-10 =
-
-* Fix - Fixed issue where non-ticket products were removed from the cart when the "Update Cart" button was pressed
-* Fix - Resolved bug where site fees were being calculated on the entire cart regardless of whether or not all of the items in the cart were tickets
-
-= [4.0] 2015-12-02 =
-
-* Fix - Compatibility fix with PHP 5.2 when accessing the WooCommerce cart
-
-= [3.12.1] 2015-11-12 =
-
-* Fix - Ensure translations are loaded as expected (our thanks to Dirk for highlighting this issue)
-* Fix - Update some strings to ensure they can be translated as expected
-
-= [3.12] 2015-11-04 =
+= [0.1.0] 2017-09-07 =
 
 * Initial release

--- a/src/Commerce/Command.php
+++ b/src/Commerce/Command.php
@@ -61,6 +61,9 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	 *      - refunded
 	 * ---
 	 *
+	 * [--dont-send-emails]
+	 * : if set emails will not be sent during the order generation process.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *      wp commerce generate-paypal-orders 23
@@ -71,6 +74,7 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	 *      wp commerce generate-paypal-orders 23 --attendees_min=3
 	 *      wp commerce generate-paypal-orders 23 --attendees_min=3 --attendees_max=10
 	 *      wp commerce generate-paypal-orders 23 --attendees_min=3 --attendees_max=10 --order_status=denied
+	 *      wp commerce generate-paypal-orders 23,31 --count=89 --dont-send-emails
 	 *
 	 * @subcommand generate-paypal-orders
 	 *
@@ -124,12 +128,16 @@ class Tribe__Cli__Commerce__Command extends WP_CLI_Command {
 	 *      - refunded
 	 * ---
 	 *
+	 * [--dont-send-emails]
+	 * : if set emails will not be sent during the order update process.
+	 *
 	 * ## EXAMPLES
 	 *
 	 *      wp commerce update-paypal-order-status 23 --order_status=completed
 	 *      wp commerce update-paypal-order-status 23 --order_status=pending
 	 *      wp commerce update-paypal-order-status 23 --order_status=denied
 	 *      wp commerce update-paypal-order-status 23 --order_status=refunded
+	 *      wp commerce update-paypal-order-status 23 --order_status=completed --dont-send-emails
 	 *
 	 * @subcommand update-paypal-order-status
 	 *

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -42,8 +42,6 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 		$progress  = make_progress_bar( 'Generating orders', $orders_count );
 		$generated = array();
 
-		$this->hijack_request_flow();
-
 		for ( $k = 0; $k < $orders_count; $k ++ ) {
 			$user_id    = 0;
 			$ticket_qty = array();

--- a/src/Commerce/Generator/PayPal/CLI.php
+++ b/src/Commerce/Generator/PayPal/CLI.php
@@ -14,6 +14,11 @@ use function WP_CLI\Utils\make_progress_bar;
 class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 
 	/**
+	 * @var bool Whether emails should be sent while during the command execution or not.
+	 */
+	protected $dont_send_emails = false;
+
+	/**
 	 * @var string The current order status, a utility field
 	 */
 	protected $order_status;
@@ -35,6 +40,8 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 
 		$orders_count = $this->parse_count( $assoc_args );
 		$order_status = $this->parse_order_status( $assoc_args );
+
+		$this->parse_send_emails( $assoc_args );
 
 		$ticket_ids_list = implode( ', ', $ticket_ids );
 		WP_CLI::log( "Generating {$orders_count} PayPal orders for tickets {$ticket_ids_list}" );
@@ -317,8 +324,9 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 			return $postarr;
 		} );
 
-		// no, do not send emails to the fake attendees
-		add_filter( 'tribe_tickets_tpp_send_mail', '__return_false' );
+		if ( $this->dont_send_emails ) {
+			add_filter( 'tribe_tickets_tpp_send_mail', '__return_false' );
+		}
 
 		// do not `die` after generating tickets
 		add_filter( 'tribe_exit', function () {
@@ -570,6 +578,8 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 		$order_id     = $this->parse_order_id( $args );
 		$order_status = $this->parse_order_status( $assoc_args );
 
+		$this->parse_send_emails( $assoc_args );
+
 		$order = Order::from_order_id( $order_id, true );
 
 		WP_CLI::log( "Settings the order status of Order {$args[0]} to {$order_status}..." );
@@ -622,5 +632,31 @@ class Tribe__Cli__Commerce__Generator__PayPal__CLI {
 		}
 
 		return $order_id;
+	}
+
+	/**
+	 * Parses the `--dont-send-emails` flag argument and sets the class property accordingly
+	 *
+	 * @since 0.2.1
+	 *
+	 * @param array $assoc_args
+	 */
+	public function parse_send_emails( array $assoc_args ) {
+		$this->dont_send_emails = isset( $assoc_args['dont-send-emails'] ) && (bool) $assoc_args['dont-send-emails'];
+	}
+
+	/**
+	 * Backups the stock for a ticket before the generation kicks in.
+	 *
+	 * @since 0.2.1
+	 *
+	 * @param int $ticket_id
+	 */
+	protected function backup_ticket_stock( $ticket_id ) {
+		$backup_key  = Meta_Keys::$stock_backup_meta_key;
+		$saved_stock = get_post_meta( $ticket_id, $backup_key, true );
+		if ( '' === $saved_stock ) {
+			update_post_meta( $ticket_id, $backup_key, get_post_meta( $ticket_id, '_stock', true ) );
+		}
 	}
 }

--- a/src/Meta_Keys.php
+++ b/src/Meta_Keys.php
@@ -19,4 +19,11 @@ class Tribe__Cli__Meta_Keys {
 	 * @var string
 	 */
 	public static $total_sales_backup_meta_key = '_tribe_cli_total_sales_backup';
+
+	/**
+	 * Meta key used to store a backup of the stock for a commerce related post.
+	 *
+	 * @var string
+	 */
+	public static $stock_backup_meta_key = '_tribe_cli_stock_backup';
 }


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/98563#note-19

This PR:
* fixes a `_stock` meta related issue with generated orders
* changes the default behavior to send emails for generated orders
* updates the readme to make sense