### PR TITLE
Add post transient deletion management

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -152,6 +152,9 @@ Our Premium Plugins:
 
 == Changelog ==
 
+= [0.2.4] 2017-03-08 =
+* Added support for post transients deletion
+
 = [0.2.3] 2017-03-07 =
 * Fix support for new and old versions of Event Tickets and Event Tickets Plus by internalizing the `Tribe__Tickets__RSVP::generate_security_code` method
 

--- a/readme.txt
+++ b/readme.txt
@@ -154,6 +154,7 @@ Our Premium Plugins:
 
 = [0.2.4] 2017-03-08 =
 * Added support for post transients deletion
+* Changed the name of the command to generate events from `tribe-events-generator` to `tribe events-generator`
 
 = [0.2.3] 2017-03-07 =
 * Fix support for new and old versions of Event Tickets and Event Tickets Plus by internalizing the `Tribe__Tickets__RSVP::generate_security_code` method

--- a/src/Service_Providers/Events.php
+++ b/src/Service_Providers/Events.php
@@ -65,7 +65,7 @@ class Tribe__Cli__Service_Providers__Events extends Tribe__Cli__Service_Provider
 		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-			WP_CLI::add_command( 'tribe-events-generator', $this->container->make( 'Tribe__Cli__Events__Generator__CLI' ), array( 'shortdesc' => $this->get_display_name() ) );
+			WP_CLI::add_command( 'tribe events-generator', $this->container->make( 'Tribe__Cli__Events__Generator__CLI' ), array( 'shortdesc' => $this->get_display_name() ) );
 		}
 	}
 }

--- a/src/Service_Providers/Utils.php
+++ b/src/Service_Providers/Utils.php
@@ -1,0 +1,39 @@
+<?php
+class Tribe__Cli__Service_Providers__Utils extends Tribe__Cli__Service_Providers__Base {
+
+	/**
+	 * Returns each plugin required by this one to run
+	 *
+	 * @return array {
+	 *      List of required plugins.
+	 *
+	 * @param string $short_name   Shortened title of the plugin
+	 * @param string $class        Main PHP class
+	 * @param string $thickbox_url URL to download plugin
+	 * @param string $min_version  Optional. Minimum version of plugin needed.
+	 * @param string $ver_compare  Optional. Constant that stored the currently active version.
+	 *                             }
+	 */
+	protected function get_requisite_plugins() {
+		// Utils should always be loaded, no Modern Tribe specific plugins required.
+		return array();
+	}
+
+	/**
+	 * Returns the display name of this functionality.
+	 *
+	 * @return string
+	 */
+	protected function get_display_name() {
+		return 'Modern Tribe CLI utilities';
+	}
+
+	/**
+	 * Binds and sets up implementations.
+	 */
+	public function register() {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			WP_CLI::add_command( 'tribe post-transient', $this->container->make( 'Tribe__Cli__Utils__Post_Transients' ) );
+		}
+	}
+}

--- a/src/Service_Providers/Utils.php
+++ b/src/Service_Providers/Utils.php
@@ -1,8 +1,16 @@
 <?php
+
+/**
+ * Class Tribe__Cli__Service_Providers__Utils
+ *
+ * @since 0.2.4
+ */
 class Tribe__Cli__Service_Providers__Utils extends Tribe__Cli__Service_Providers__Base {
 
 	/**
 	 * Returns each plugin required by this one to run
+	 *
+	 * @since 0.2.4
 	 *
 	 * @return array {
 	 *      List of required plugins.
@@ -22,6 +30,8 @@ class Tribe__Cli__Service_Providers__Utils extends Tribe__Cli__Service_Providers
 	/**
 	 * Returns the display name of this functionality.
 	 *
+	 * @since 0.2.4
+	 *
 	 * @return string
 	 */
 	protected function get_display_name() {
@@ -30,6 +40,8 @@ class Tribe__Cli__Service_Providers__Utils extends Tribe__Cli__Service_Providers
 
 	/**
 	 * Binds and sets up implementations.
+	 *
+	 * @since 0.2.4
 	 */
 	public function register() {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {

--- a/src/Utils/Post_Transients.php
+++ b/src/Utils/Post_Transients.php
@@ -1,0 +1,247 @@
+<?php
+
+class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
+
+	/**
+	 * Deletes post transients created by Modern Tribe code.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [<key>]
+	 * : Key for the post transient.
+	 *
+	 * [--post_id=<post_id>]
+	 * : Delete post transients on this post only.
+	 *
+	 * [--post_type=<post_type>]
+	 * : Delete post transients on this post type only.
+	 *
+	 * [--all]
+	 * : Delete all post transients on all posts.
+	 *
+	 * [--expired]
+	 * : Delete all expired post transients on the post(s).
+	 *
+	 * ## EXAMPLES
+	 *
+	 *      # Delete all post transients with an `attendee_cache` key on all posts
+	 *      wp tribe post-transient delete attendees_cache
+	 *
+	 *      # Delete all post transients with an `attendee_cache` key on the post with an ID of `23`
+	 *      wp tribe post-transient delete attendees_cache --post_id=23
+	 *
+	 *      # Delete all post transients with an `attendee_cache` key on any post of the `tribe_events` type
+	 *      wp tribe post-transient delete attendees_cache --post_type=tribe_events
+	 *
+	 *      # Delete all post transients with an `attendee_cache` key on the post with an ID of `23` of the `tribe_events` type
+	 *      wp tribe post-transient delete attendees_cache --post_id=23 --post_type=tribe_events
+	 *
+	 *      # Delete all post transients on all posts
+	 *      wp tribe post-transient delete --all
+	 *
+	 *      # Delete all post transients on the post with an ID of `23`
+	 *      wp tribe post-transient delete --all --post_id=23
+	 *
+	 *      # Delete all post transients on the post with an ID of `23` and a `tribe_events` post type
+	 *      wp tribe post-transient delete --all --post_id=23 --post_type=tribe_events
+	 *
+	 *      # Delete all expired post transients on all posts
+	 *      wp tribe post-transient delete --expired
+	 *
+	 *      # Delete all expired `attendees_cache` post transients on all posts
+	 *      wp tribe post-transient delete attendees_cache --expired
+	 *
+	 *
+	 * @subcommand delete
+	 *
+	 * @since      0.1.0
+	 */
+	public function delete( array $args = [], array $assoc_args = [] ) {
+		$key = isset( $args[0] ) ? $args[0] : false;
+
+		$post_id = false;
+		if ( isset( $assoc_args['post_id'] ) ) {
+			$post_id = $this->check_post_id( $assoc_args );
+			$this->check_post( $post_id );
+		}
+
+		$post_type = false;
+		if ( isset( $assoc_args['post_type'] ) ) {
+			$post_type = $this->check_post_type( $assoc_args );
+		}
+
+		$all     = isset( $assoc_args['all'] );
+		$expired = isset( $assoc_args['expired'] );
+
+		$this->check_argument_combinations( $key, $post_id, $post_type, $all, $expired );
+
+		global $_wp_using_ext_object_cache;
+
+		if ( $_wp_using_ext_object_cache ) {
+			if ( empty( $key ) || empty( $post_id ) ) {
+				$message = __(
+					'Your website is using object caching to store post transients; you will need to specify the post ID and key for each entry using the format "wp tribe post-transient delete <key> --post_id=<post_id>"',
+					'tribe-cli'
+				);
+				WP_CLI::error( $message );
+			}
+			$entries = $this->delete_from_object_cache( $key, $post_id );
+			WP_CLI::success( "{$entries} post transients deleted from object cache." );
+
+			return;
+		}
+
+		$rows = $this->delete_from_database( $key, $post_id, $post_type, $all, $expired );
+		WP_CLI::success( "{$rows} post transients deleted." );
+	}
+
+	/**
+	 * @param array $assoc_args
+	 *
+	 * @return mixed
+	 */
+	protected function check_post_id( array $assoc_args ) {
+		$post_id = filter_var( $assoc_args['post_id'], FILTER_VALIDATE_INT );
+		if ( ! $post_id ) {
+			WP_CLI::error( "{$post_id} is not a valid post ID" );
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * @param $post_id
+	 */
+	protected function check_post( $post_id ) {
+		$post = get_post( $post_id );
+
+		if ( empty( $post ) ) {
+			WP_CLI::success( "No post found with an ID of {$post_id}." );
+		}
+	}
+
+	/**
+	 * @param array $assoc_args
+	 */
+	protected function check_post_type( array $assoc_args ) {
+		$post_type = $assoc_args['post_type'];
+		// we only check if it's a string, not if the post_type is defined in WP
+		// as it might be from a deactivated plugin
+		$post_type = filter_var( $post_type, FILTER_SANITIZE_STRING );
+
+		if ( ! $post_type || is_numeric( $post_type ) ) {
+			WP_CLI::error( "{$post_type} is not a valid post type." );
+		}
+
+		return trim( $post_type );
+	}
+
+	/**
+	 * @param $key
+	 * @param $post_id
+	 * @param $post_type
+	 * @param $all
+	 * @param $expired
+	 */
+	protected function check_argument_combinations( $key, $post_id, $post_type, $all, $expired ) {
+		$bitmask = (int) ( (bool) $key ) * 10000
+		           + (int) ( (bool) $post_id ) * 1000
+		           + (int) ( (bool) $post_type ) * 100
+		           + (int) $all * 10
+		           + (int) $expired;
+
+		switch ( $bitmask ) {
+			case 0:
+				WP_CLI::error( __( 'Provide at least one parameter.', 'tribe-cli' ) );
+				break;
+			case 11111:
+			case 10011:
+			case 11011:
+			case 10111:
+			case 1111:
+			case 1011:
+			case 111:
+			case 11:
+				WP_CLI::error( __( 'Either delete all transients or just the expired ones', 'tribe-cli' ) );
+				break;
+			case 11010:
+			case 11110:
+				WP_CLI::error( __( "Either delete all transients on post {$post_id } or just the ones with the {$key} key", 'tribe-cli' ) );
+				break;
+			default:
+				// legit combination
+				break;
+		}
+	}
+
+	/**
+	 * @param string $key
+	 * @param int    $post_id
+	 */
+	protected function delete_from_object_cache( $key = null, $post_id = null ) {
+		return wp_cache_delete( "tribe_{$key}-{$post_id}", "tribe_post_meta_transient-{$post_id}" );
+	}
+
+	protected function delete_from_database( $key, $post_id, $post_type, $all, $expired ) {
+		/** @var wpdb $wpdb */
+		global $wpdb;
+
+		if ( $key ) {
+			$where[] = $wpdb->prepare( "meta_key IN (%s,%s)", '_transient_' . $key, '_transient_timeout_' . $key );
+		}
+
+		if ( $all ) {
+			$where[] = "meta_key LIKE '_transient_%' OR meta_key LIKE '_transient_timeout_%'";
+		}
+
+		if ( $post_id ) {
+			$where[] = $wpdb->prepare( "post_id = %d", $post_id );
+		}
+
+		if ( $post_type ) {
+			$post_ids_query = $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_type = %s", $post_type );
+			WP_CLI::debug( "Post type is {$post_type}, getting post IDs with query: {$post_ids_query}" );
+			$ids = $wpdb->get_col( $post_ids_query );
+
+			if ( empty( $ids ) ) {
+				WP_CLI::success( "No posts of type {$post_type} found." );
+
+				exit;
+			}
+
+			$ids = implode( ',', $ids );
+			WP_CLI::debug( "Post type is {$post_type}, found these IDs: {$ids}" );
+			$where[] = "post_id IN ({$ids})";
+		}
+
+		if ( $expired ) {
+			$expired_ids_query = $wpdb->prepare(
+				"SELECT meta_id, meta_key FROM {$wpdb->postmeta} WHERE meta_key LIKE '_transient_timeout_%' AND meta_value <= %d",
+				time()
+			);
+			WP_CLI::debug( "Expired is set, getting expired meta IDs with query: {$expired_ids_query}" );
+			$expired_meta_ids = $wpdb->get_results( $expired_ids_query );
+
+			if ( empty( $expired_meta_ids ) ) {
+				WP_CLI::success( "No expired post transients found." );
+
+				exit;
+			}
+
+			$meta_ids = implode( ',', $expired_meta_ids );
+			WP_CLI::debug( "Expired is set, found these meta_ids: {$meta_ids}" );
+			$where[] = "meta_id IN {$meta_ids}";
+		}
+
+		if ( empty( $where ) ) {
+			return 0;
+		}
+
+		$where_predicates = count( $where ) ? ' WHERE ' . implode( ' AND ', $where ) : '';
+		$query            = "DELETE FROM {$wpdb->postmeta} {$where_predicates}";
+
+		WP_CLI::debug( 'Running query: ' . $query );
+
+		return $wpdb->query( $query );
+	}
+}

--- a/src/Utils/Post_Transients.php
+++ b/src/Utils/Post_Transients.php
@@ -1,5 +1,10 @@
 <?php
 
+/**
+ * Class Tribe__Cli__Utils__Post_Transients
+ *
+ * @since 0.2.4
+ */
 class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 
 	/**
@@ -54,7 +59,7 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	 *
 	 * @subcommand delete
 	 *
-	 * @since      0.1.0
+	 * @since      0.2.4
 	 */
 	public function delete( array $args = [], array $assoc_args = [] ) {
 		$key = isset( $args[0] ) ? $args[0] : false;
@@ -96,9 +101,13 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	}
 
 	/**
+	 * Validates the post ID provided by the user, if any.
+	 *
+	 * @since 0.2.4
+	 *
 	 * @param array $assoc_args
 	 *
-	 * @return mixed
+	 * @return int
 	 */
 	protected function check_post_id( array $assoc_args ) {
 		$post_id = filter_var( $assoc_args['post_id'], FILTER_VALIDATE_INT );
@@ -110,6 +119,10 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	}
 
 	/**
+	 * Validates the post if the user provided a post ID.
+	 *
+	 * @since 0.2.4
+	 *
 	 * @param $post_id
 	 */
 	protected function check_post( $post_id ) {
@@ -121,7 +134,13 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	}
 
 	/**
+	 * Validates the post type if provided by the user.
+	 *
+	 * @since 0.2.4
+	 *
 	 * @param array $assoc_args
+	 *
+	 * @return string
 	 */
 	protected function check_post_type( array $assoc_args ) {
 		$post_type = $assoc_args['post_type'];
@@ -137,11 +156,15 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	}
 
 	/**
-	 * @param $key
-	 * @param $post_id
-	 * @param $post_type
-	 * @param $all
-	 * @param $expired
+	 * Validates the command argument combination to make sure it makes sense.
+	 *
+	 * @since 0.2.4
+	 *
+	 * @param string $key
+	 * @param int    $post_id
+	 * @param string $post_type
+	 * @param bool   $all
+	 * @param bool   $expired
 	 */
 	protected function check_argument_combinations( $key, $post_id, $post_type, $all, $expired ) {
 		$bitmask = (int) ( (bool) $key ) * 10000
@@ -152,7 +175,7 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 
 		switch ( $bitmask ) {
 			case 0:
-				WP_CLI::error( __( 'Provide at least one parameter.', 'tribe-cli' ) );
+				WP_CLI::error( __( 'Provide at least one parameter; use `--help` to know more.', 'tribe-cli' ) );
 				break;
 			case 11111:
 			case 10011:
@@ -162,7 +185,7 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 			case 1011:
 			case 111:
 			case 11:
-				WP_CLI::error( __( 'Either delete all transients or just the expired ones', 'tribe-cli' ) );
+				WP_CLI::error( __( 'Either delete all transients (using `--all`) or just the expired ones (using `--expired`).', 'tribe-cli' ) );
 				break;
 			case 11010:
 			case 11110:
@@ -175,14 +198,33 @@ class Tribe__Cli__Utils__Post_Transients extends WP_CLI_Command {
 	}
 
 	/**
+	 * Deletes a post transient stored in the object cache.
+	 *
+	 * @since 0.2.4
+	 *
 	 * @param string $key
 	 * @param int    $post_id
+	 *
+	 * @return bool
 	 */
-	protected function delete_from_object_cache( $key = null, $post_id = null ) {
+	protected function delete_from_object_cache( $key, $post_id ) {
 		return wp_cache_delete( "tribe_{$key}-{$post_id}", "tribe_post_meta_transient-{$post_id}" );
 	}
 
-	protected function delete_from_database( $key, $post_id, $post_type, $all, $expired ) {
+	/**
+	 * Deletes a post transient stored in the database.
+	 *
+	 * @since 0.2.4
+	 *
+	 * @param string $key
+	 * @param int    $post_id
+	 * @param string $post_type
+	 * @param bool   $all
+	 * @param bool   $expired
+	 *
+	 * @return false|int False if the post transient(s) could not be delted, the number of deleted post transients otherwise.
+	 */
+	protected function delete_from_database( $key = null, $post_id = null, $post_type = null, $all = null, $expired = null ) {
 		/** @var wpdb $wpdb */
 		global $wpdb;
 

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -45,6 +45,7 @@ function tribe_cli_init() {
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tribe_Commerce' );
 	$container->register( 'Tribe__Cli__Service_Providers__Tickets_Plus' );
+	$container->register( 'Tribe__Cli__Service_Providers__Utils' );
 }
 
 include_once(dirname(__FILE__) . '/src/functions/template.php');


### PR DESCRIPTION
Ticket: https://central.tri.be/issues/101081

Related: https://github.com/moderntribe/event-tickets-plus/pull/505 and https://github.com/moderntribe/event-tickets/pull/681

This PR:
* adds the utils command namespace in `wp tribe`
* adds the `wp tribe post-transient delete` command independent of Tribe plugins being active or not.
* changes the events generator command path from `wp tribe-events-generator` to `wp tribe events-generator` the ratio here is to group any "utility" command that might use or be related to more than 1 plugin in the `tribe` namespace