### PR TITLE
#121365 - utilitize the same data for all user fields when generating…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "events-generator",
-  "version": "0.1",
+  "version": "0.2.5",
   "repository": "git@github.com:moderntribe/events-generator.git",
   "_zipname": "the-events-calendar-generator",
   "_zipfoldername": "the-events-calendar-generator",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@
 Contributors: ModernTribe, barry.hughes, bordoni, borkweb, brianjessee, brook-tribe, faction23, geoffgraham, ggwicz, jazbek, jbrinley, joshlimecuda, leahkoerper, lucatume, mastromktg, mat-lipe, mdbitz, neillmcshea, nicosantos, peterchester, reid.peifer, roblagatta, ryancurban, shane.pearlman, thatdudebutch,  zbtirrell
 Tags: widget, events, simple, tooltips, grid, month, list, calendar, event, venue, community, registration, api, dates, date, plugin, posts, sidebar, template, theme, time, google maps, google, maps, conference, workshop, concert, meeting, seminar, summit, forum, shortcode, The Events Calendar, The Events Calendar PRO, Community Events, tickets, RSVP, registration
 Requires at least: 3.9
-Stable tag: 0.2.4
+Stable tag: 0.2.5
 Tested up to: 4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -151,6 +151,9 @@ Our Premium Plugins:
 * <a href="http://m.tri.be/18h9" target="_blank">The Events Calendar: iCal Importer</a>
 
 == Changelog ==
+
+= [0.2.5] TBD =
+* Fix in Woocommerce user generation to set the faker data once and add it throughout the user meta instead of in each field [121365]
 
 = [0.2.4] 2018-03-08 =
 * Added support for post transients deletion

--- a/src/Main.php
+++ b/src/Main.php
@@ -12,7 +12,7 @@ class Tribe__Cli__Main extends tad_DI52_ServiceProvider {
 	 *
 	 * @var string
 	 */
-	const VERSION = '0.1';
+	const VERSION = '0.2.5';
 
 	/**
 	 * Plugin directory name.

--- a/src/WooCommerce/Orders_Generator.php
+++ b/src/WooCommerce/Orders_Generator.php
@@ -1,5 +1,6 @@
 <?php
 
+
 /**
  * Class Tribe__CLI__WooCommerce__Orders_Generator
  *
@@ -7,10 +8,11 @@
  *
  * A modified version of the class found in 75nineteen/order-simulator-woocommerce
  *
- * @link https://github.com/75nineteen/order-simulator-woocommerce
- * @link https://raw.githubusercontent.com/75nineteen/order-simulator-woocommerce/master/woocommerce-order-simulator.php
+ * @link  https://github.com/75nineteen/order-simulator-woocommerce
+ * @link  https://raw.githubusercontent.com/75nineteen/order-simulator-woocommerce/master/woocommerce-order-simulator.php
  */
 class Tribe__Cli__WooCommerce__Orders_Generator {
+
 	protected $users = array();
 
 	/**
@@ -70,7 +72,7 @@ class Tribe__Cli__WooCommerce__Orders_Generator {
 			$payment_method     = array_rand( $available_gateways );
 
 			// process checkout
-			$data           = array(
+			$data     = array(
 				'billing_country'    => get_user_meta( $user_id, 'billing_country', true ),
 				'billing_first_name' => get_user_meta( $user_id, 'billing_first_name', true ),
 				'billing_last_name'  => get_user_meta( $user_id, 'billing_last_name', true ),
@@ -152,12 +154,26 @@ class Tribe__Cli__WooCommerce__Orders_Generator {
 		$faker->addProvider( new Faker\Provider\en_US\Address( $faker ) );
 		$faker->addProvider( new Faker\Provider\en_US\PhoneNumber( $faker ) );
 
-		$user = array(
-			'user_login' => $faker->userName,
-			'user_pass'  => 'password',
-			'user_email' => $faker->email,
+		//set user from Faker Press and use in all fields to keep the user the same
+		$user_default = array(
+			'login'      => $faker->userName,
+			'email'      => $faker->email,
 			'first_name' => $faker->firstName,
 			'last_name'  => $faker->lastName,
+			'country'    => $faker->country,
+			'address_1'  => $faker->streetAddress,
+			'city'       => $faker->city,
+			'state'      => $faker->state,
+			'postcode'   => $faker->postcode,
+			'phone'      => $faker->phoneNumber,
+		);
+
+		$user = array(
+			'user_login' => $user_default['login'],
+			'user_pass'  => 'password',
+			'user_email' => $user_default['email'],
+			'first_name' => $user_default['first_name'],
+			'last_name'  => $user_default['last_name'],
 			'role'       => 'customer',
 		);
 
@@ -165,24 +181,24 @@ class Tribe__Cli__WooCommerce__Orders_Generator {
 
 		// billing/shipping address
 		$meta = array(
-			'billing_country'                          => $faker->country,
-			'billing_first_name'                       => $faker->firstName,
-			'billing_last_name'                        => $faker->lastName,
-			'billing_address_1'                        => $faker->streetAddress,
-			'billing_city'                             => $faker->city,
-			'billing_state'                            => $faker->state,
-			'billing_postcode'                         => $faker->postcode,
-			'billing_email'                            => $faker->email,
-			'billing_phone'                            => $faker->phoneNumber,
-			'shipping_country'                         => $faker->country,
-			'shipping_first_name'                      => $faker->firstName,
-			'shipping_last_name'                       => $faker->lastName,
-			'shipping_address_1'                       => $faker->streetAddress,
-			'shipping_city'                            => $faker->city,
-			'shipping_state'                           => $faker->state,
-			'shipping_postcode'                        => $faker->postcode,
-			'shipping_email'                           => $faker->email,
-			'shipping_phone'                           => $faker->phoneNumber,
+			'billing_country'                          => $user_default['country'],
+			'billing_first_name'                       => $user_default['first_name'],
+			'billing_last_name'                        => $user_default['last_name'],
+			'billing_address_1'                        => $user_default['address_1'],
+			'billing_city'                             => $user_default['city'],
+			'billing_state'                            => $user_default['state'],
+			'billing_postcode'                         => $user_default['postcode'],
+			'billing_email'                            => $user_default['email'],
+			'billing_phone'                            => $user_default['phone'],
+			'shipping_country'                         => $user_default['country'],
+			'shipping_first_name'                      => $user_default['first_name'],
+			'shipping_last_name'                       => $user_default['last_name'],
+			'shipping_address_1'                       => $user_default['address_1'],
+			'shipping_city'                            => $user_default['city'],
+			'shipping_state'                           => $user_default['state'],
+			'shipping_postcode'                        => $user_default['postcode'],
+			'shipping_email'                           => $user_default['email'],
+			'shipping_phone'                           => $user_default['phone'],
 			Tribe__Cli__Meta_Keys::$generated_meta_key => 1,
 		);
 

--- a/tribe-cli.php
+++ b/tribe-cli.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: Tribe CLI
 Description: A collection of WP-CLI utilities for testing and maintenance purposes.
-Version: 0.2.4
+Version: 0.2.5
 Author: Modern Tribe, Inc.
 Author URI: http://m.tri.be/21
 Text Domain: tribe-cli


### PR DESCRIPTION
… a user

_Ref:_ [C#121365](https://central.tri.be/issues/121365)

The data that is being generated using Faker Press was unique every time it is called. Thus, $faker->firstName called three times was producing 3 different first names. 

When creating a user we would do that, call it for the account name, the billing name, and shipping name. 

I changed to call it once for all the information and then use that information to populate the user so it remains the same. 