### PR TITLE
fix(sent emails): Add filter to prevent sending emails.

### DIFF
--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -104,7 +104,6 @@ class CLI {
 		} else  {
 			$status = $assoc_args['status'];
 		}
-		error_log($status);
 
 		// Generate orders
 		$tickets      = Tribe__Tickets_Plus__Commerce__WooCommerce__Main::get_instance();

--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -86,12 +86,12 @@ class CLI {
 		}
 
 		$legit_stati = [
+			'cancelled',
+			'completed',
+			'failed',
 			'pending',
 			'processing',
-			'completed',
-			'cancelled',
 			'refunded',
-			'failed',
 		];
 
 		if ( ! empty( $assoc_args['status'] ) && ! in_array( $assoc_args['status'], $legit_stati, true ) ) {
@@ -104,6 +104,7 @@ class CLI {
 		} else  {
 			$status = $assoc_args['status'];
 		}
+		error_log($status);
 
 		// Generate orders
 		$tickets      = Tribe__Tickets_Plus__Commerce__WooCommerce__Main::get_instance();

--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -30,17 +30,21 @@ class CLI {
 	 */
 	public function __construct() {
 
+		// don't run if we're not using the CLI!
+		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
 		$wc_emails = \WC_Emails::instance();
+
 		// disable all emails
 		foreach ( $wc_emails->get_emails() as $email_id => $email ) {
 			$key   = 'woocommerce_' . $email->id . '_settings';
 			$value = get_option( $key );
+			// disable proactively
+			$value['enabled'] = 'no';
 
-			if ( isset( $value['enabled'] ) ) {
-				$value['enabled'] = 'no';
-
-				update_option( $key, $value );
-			}
+			//add_filter( 'option_' . $key, '__return_false__' );
 		}
 	}
 
@@ -104,8 +108,6 @@ class CLI {
 		} else  {
 			$status = $assoc_args['status'];
 		}
-		error_log($status);
-
 		// Generate orders
 		$tickets      = Tribe__Tickets_Plus__Commerce__WooCommerce__Main::get_instance();
 		$post_tickets = $tickets->get_tickets_ids( $post_id );

--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -44,7 +44,7 @@ class CLI {
 			// disable proactively
 			$value['enabled'] = 'no';
 
-			//add_filter( 'option_' . $key, '__return_false__' );
+			add_filter( 'option_' . $key, '__return_false__' );
 		}
 	}
 

--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -622,8 +622,6 @@ class CLI {
 			return;
 		}
 
-		error_log('prep');
-
 		// avoid sending emails for fake orders
 		add_filter( 'woocommerce_email_classes', [ $this, 'filter_woocommerce_email_classes' ], 999 );
 

--- a/src/Payouts/Generator/CLI.php
+++ b/src/Payouts/Generator/CLI.php
@@ -28,25 +28,7 @@ class CLI {
 	 *
 	 * @since 0.2.8
 	 */
-	public function __construct() {
-
-		// don't run if we're not using the CLI!
-		if ( ! defined( 'WP_CLI' ) || ! WP_CLI ) {
-			return;
-		}
-
-		$wc_emails = \WC_Emails::instance();
-
-		// disable all emails
-		foreach ( $wc_emails->get_emails() as $email_id => $email ) {
-			$key   = 'woocommerce_' . $email->id . '_settings';
-			$value = get_option( $key );
-			// disable proactively
-			$value['enabled'] = 'no';
-
-			add_filter( 'option_' . $key, '__return_false__' );
-		}
-	}
+	public function __construct() {}
 
 	/**
 	 * Generate WC orders with payouts
@@ -191,6 +173,7 @@ class CLI {
 	 * @param array $assoc_args (currently unused) additional passed arguments
 	 */
 	public function reset_payouts( array $args = null, array $assoc_args = null ) {
+		$this->prep();
 		$post_id = $args[0];
 		$post    = get_post( absint( $post_id ) );
 
@@ -330,6 +313,7 @@ class CLI {
 	 * @param array $assoc_args (currently unused) additional passed arguments
 	 */
 	public function delete_payouts( array $args = null, array $assoc_args = null ) {
+		$this->prep();
 		$order_id    = $args[0];
 
 		if ( empty( $order_id ) ) {
@@ -349,6 +333,7 @@ class CLI {
 	 * @param array $assoc_args additional passed arguments
 	 */
 	public function update_payouts( array $args = null, array $assoc_args = null ) {
+		$this->prep();
 		$order_id    = $args[0];
 		$status = $assoc_args['status'];
 
@@ -391,6 +376,7 @@ class CLI {
 	 * @param int $order_id
 	 */
 	public function delete_payout( $order_id ) {
+		$this->prep();
 		$repository = tribe_payouts();
 		$repository->by( 'order', $order_id );
 		$repository->set_found_rows( true );
@@ -412,7 +398,8 @@ class CLI {
 	 *
 	 * @since 0.2.8
 	 */
-	public function generate_orders( $count, array $product_ids, array $args ) {
+	private function generate_orders( $count, array $product_ids, array $args ) {
+		$this->prep();
 		/** @var WooCommerce $woocommerce */
 		global $woocommerce;
 		$order_ids = [];
@@ -547,7 +534,7 @@ class CLI {
 	 *
 	 * @return int|\WP_Error
 	 */
-	public function create_user() {
+	private function create_user() {
 		$faker = Faker\Factory::create();
 		$faker->addProvider( new Faker\Provider\en_US\Address( $faker ) );
 		$faker->addProvider( new Faker\Provider\en_US\PhoneNumber( $faker ) );
@@ -614,7 +601,7 @@ class CLI {
 	 *
 	 * @return int
 	 */
-	public function get_random_user() {
+	private function get_random_user() {
 		if ( ! $this->users ) {
 			$this->users = get_users( [ 'role' => 'Subscriber', 'fields' => 'ID' ] );
 		}
@@ -627,5 +614,45 @@ class CLI {
 		$idx    = rand( 0, $length - 1 );
 
 		return $this->users[ $idx ];
+	}
+
+	private function prep() {
+		// can't be too careful!
+		if ( !defined( 'WP_CLI' ) || ! WP_CLI ) {
+			return;
+		}
+
+		error_log('prep');
+
+		// avoid sending emails for fake orders
+		add_filter( 'woocommerce_email_classes', [ $this, 'filter_woocommerce_email_classes' ], 999 );
+
+		$wc_emails = \WC_Emails::instance();
+
+		// disable all emails
+		foreach ( $wc_emails->get_emails() as $email_id => $email ) {
+			$key   = 'woocommerce_' . $email->id . '_settings';
+			$value = get_option( $key );
+			// disable proactively
+			$value['enabled'] = 'no';
+
+			add_filter( 'option_' . $key, '__return_false__' );
+		}
+	}
+
+	/**
+	 * Filters the classes of emails WooCommerce will send to avoid sending tickets confirmations
+	 * for generated tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $classes An array of classes that WooCommerce will call to send confirmation emails.
+	 *
+	 * @return array The filtered classes array
+	 */
+	private function filter_woocommerce_email_classes( $classes ) {
+		unset( $classes['Tribe__Tickets__Woo__Email'] );
+
+		return [];
 	}
 }

--- a/src/Service_Providers/Payouts.php
+++ b/src/Service_Providers/Payouts.php
@@ -69,5 +69,24 @@ class Payouts extends Base {
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'tribe payouts', $this->container->make( Command::class ), array( 'shortdesc' => $this->get_display_name() ) );
 		}
+
+		// avoid sending emails for fake orders
+		add_filter( 'woocommerce_email_classes', array( $this, 'filter_woocommerce_email_classes' ), 999 );
+	}
+
+	/**
+	 * Filters the classes of emails WooCommerce will send to avoid sending tickets confirmations
+	 * for generated tickets.
+	 *
+	 * @since TBD
+	 *
+	 * @param array $classes An array of classes that WooCommerce will call to send confirmation emails.
+	 *
+	 * @return array The filtered classes array
+	 */
+	public function filter_woocommerce_email_classes( $classes ) {
+		unset( $classes['Tribe__Tickets__Woo__Email'] );
+
+		return $classes;
 	}
 }

--- a/src/Service_Providers/Payouts.php
+++ b/src/Service_Providers/Payouts.php
@@ -72,6 +72,7 @@ class Payouts extends Base {
 
 		// avoid sending emails for fake orders
 		add_filter( 'woocommerce_email_classes', array( $this, 'filter_woocommerce_email_classes' ), 999 );
+		add_action( 'woocommerce_email', 'unhook_alltheemails' );
 	}
 
 	/**
@@ -89,4 +90,39 @@ class Payouts extends Base {
 
 		return $classes;
 	}
+
+	/**
+	 * Unhook all WC emails
+	 * Taken straight from the WC documentation: https://docs.woocommerce.com/document/unhookremove-woocommerce-emails/
+	 *
+	 * @param \WC_Emails $email_class
+	 * @return void
+	 */
+	function unhook_alltheemails( $email_class ) {
+
+		/**
+		 * Hooks for sending emails during store events
+		 **/
+		remove_action( 'woocommerce_low_stock_notification', array( $email_class, 'low_stock' ) );
+		remove_action( 'woocommerce_no_stock_notification', array( $email_class, 'no_stock' ) );
+		remove_action( 'woocommerce_product_on_backorder_notification', array( $email_class, 'backorder' ) );
+
+		// New order emails
+		remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_pending_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_failed_to_processing_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_failed_to_completed_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_failed_to_on-hold_notification', array( $email_class->emails['WC_Email_New_Order'], 'trigger' ) );
+
+		// Processing order emails
+		remove_action( 'woocommerce_order_status_pending_to_processing_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+		remove_action( 'woocommerce_order_status_pending_to_on-hold_notification', array( $email_class->emails['WC_Email_Customer_Processing_Order'], 'trigger' ) );
+
+		// Completed order emails
+		remove_action( 'woocommerce_order_status_completed_notification', array( $email_class->emails['WC_Email_Customer_Completed_Order'], 'trigger' ) );
+
+		// Note emails
+		remove_action( 'woocommerce_new_customer_note_notification', array( $email_class->emails['WC_Email_Customer_Note'], 'trigger' ) );
+}
 }

--- a/src/Service_Providers/Payouts.php
+++ b/src/Service_Providers/Payouts.php
@@ -71,26 +71,7 @@ class Payouts extends Base {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'tribe payouts', $this->container->make( Command::class ), array( 'shortdesc' => $this->get_display_name() ) );
-
-			// avoid sending emails for fake orders
-			add_filter( 'woocommerce_email_classes', array( $this, 'filter_woocommerce_email_classes' ), 999 );
 		}
 
-	}
-
-	/**
-	 * Filters the classes of emails WooCommerce will send to avoid sending tickets confirmations
-	 * for generated tickets.
-	 *
-	 * @since TBD
-	 *
-	 * @param array $classes An array of classes that WooCommerce will call to send confirmation emails.
-	 *
-	 * @return array The filtered classes array
-	 */
-	public function filter_woocommerce_email_classes( $classes ) {
-		unset( $classes['Tribe__Tickets__Woo__Email'] );
-
-		return [];
 	}
 }

--- a/src/Service_Providers/Payouts.php
+++ b/src/Service_Providers/Payouts.php
@@ -68,6 +68,8 @@ class Payouts extends Base {
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			\WP_CLI::add_command( 'tribe payouts', $this->container->make( Command::class ), array( 'shortdesc' => $this->get_display_name() ) );
+		} else {
+			return;
 		}
 
 		// avoid sending emails for fake orders
@@ -92,11 +94,12 @@ class Payouts extends Base {
 	}
 
 	/**
-	 * Unhook all WC emails
+	 * Unhook all WC emails - we manipulate order status a lot - it creates a lot of emails.
 	 * Taken straight from the WC documentation: https://docs.woocommerce.com/document/unhookremove-woocommerce-emails/
 	 *
+	 * @since TBD
+	 *
 	 * @param \WC_Emails $email_class
-	 * @return void
 	 */
 	function unhook_alltheemails( $email_class ) {
 


### PR DESCRIPTION
Add a filter (similar to the one in ET+) to prevent emails being sent on new orders.

Earlier versions of this did wonky things to the WC settings, this bails if we're not using `WP_CLI` and uses filters instead of actually _changing options_ 😱 

:ticket: https://central.tri.be/issues/122306