### PR TITLE
Fix CT1 Events rotation

### DIFF
--- a/src/Events/Control/CLI.php
+++ b/src/Events/Control/CLI.php
@@ -1,11 +1,14 @@
 <?php
+
 namespace Tribe\CLI\Events\Control;
 
-use Tribe\CLI\Meta_Keys;
-use Tribe__Events__Main;
+use TEC\Events\Custom_Tables\V1\Models\Event;
+use TEC\Events_Pro\Custom_Tables\V1\Events\Provisional\ID_Generator;
+use TEC\Events_Pro\Custom_Tables\V1\Events\Recurrence;
 use WP_CLI_Command;
 use DateInterval;
 use WP_CLI;
+use Tribe__Date_Utils as Dates;
 
 /**
  * Class CLI.
@@ -53,35 +56,31 @@ class CLI extends WP_CLI_Command {
 	 *
 	 * @subcommand rotate
 	 *
+	 * @since      0.2.10
+	 *
 	 * @param array $args       Arguments that setup the rotation commands.
 	 * @param array $assoc_args Arguments that setup the rotation commands.
-	 *
-	 * @since 0.2.10
 	 */
 	public function rotate( $args, $assoc_args ) {
 		$start = $assoc_args['start'];
-		$end   = $assoc_args['end'];
-		$add   = $assoc_args['add'];
-		$sub   = $assoc_args['sub'];
+		$end = $assoc_args['end'];
+		$add = $assoc_args['add'];
+		$sub = $assoc_args['sub'];
 		$is_subtraction = ! empty( $sub );
 
 		$events = $this->find_events( $start, $end );
 
 		if ( empty( $events ) ) {
 			WP_CLI::error( "No events were found between Start Date '{$start}' and End Date '{$end}'" );
+
 			return;
 		}
 
-		foreach ( $events as $event ) {
-			if ( $is_subtraction ) {
-				list( $event_id, $new_start, $new_end ) = $this->move_event_backward( $event, $sub );
-				WP_CLI::success( "Event (ID: {$event_id}) dates were decreased by {$sub} to Start Date '{$new_start}' and End Date '{$new_end}'." );
-			} else {
-				list( $event_id, $new_start, $new_end ) = $this->move_event_forward( $event, $add );
-				WP_CLI::success( "Event (ID: {$event_id}) dates were increased by {$add} to Start Date '{$new_start}' and End Date '{$new_end}'." );
-			}
+		if ( tribe()->getVar( 'ct1_fully_activated' ) ) {
+			$this->move_ct1_events( $events, $is_subtraction, $sub, $add );
+		} else {
+			$this->move_events( $events, $is_subtraction, $sub, $add );
 		}
-
 	}
 
 	protected function move_event_forward( $event, $by ) {
@@ -109,6 +108,98 @@ class CLI extends WP_CLI_Command {
 	}
 
 	protected function find_events( $start, $end ) {
-		return tribe_events()->where( 'starts_between', $start, $end )->per_page( -1 )->all();
+		return tribe_events()->where( 'starts_between', $start, $end )->per_page( - 1 )->all();
+	}
+
+	private function move_ct1_events( array $events, bool $is_subtraction, $sub, $add ): void {
+		// Go from Occurrence Provisional post IDs to the Event post ID, drop duplicates.
+		$event_post_ids = array_unique( array_filter( array_map(
+			static function ( \WP_Post $event ) {
+				// This property MUST be defined, this should not fail gracefully.
+				return $event->_tec_occurrence->post_id;
+			},
+			$events
+		) ) );
+
+		$interval = $is_subtraction ? new DateInterval( $sub ) : new DateInterval( $add );
+
+		foreach ( $event_post_ids as $event_post_id ) {
+			// Move the Event date meta.
+			$timezone = get_post_meta( $event_post_id, '_EventTimezone', true );
+			foreach (
+				[
+					'_EventStartDate'    => $timezone,
+					'_EventEndDate'      => $timezone,
+					'_EventStartDateUTC' => 'UTC',
+					'_EventEndDateUTC'   => 'UTC',
+				] as $meta_key => $tz
+			) {
+				$moved = Dates::immutable( get_post_meta( $event_post_id, $meta_key, true ), $tz );
+				if ( $is_subtraction ) {
+					$meta_value = $moved->sub( $interval )->format( Dates::DBDATETIMEFORMAT );
+				} else {
+					$meta_value = $moved->add( $interval )->format( Dates::DBDATETIMEFORMAT );
+				}
+				update_post_meta( $event_post_id, $meta_key, $meta_value );
+			}
+
+			$event_model = Event::find( $event_post_id, 'post_id' );
+
+			if ( ! $event_model instanceof Event ) {
+				WP_CLI::error( "Event model for post ID {$event_post_id} not found: run the command again in debug mode to find out more." );
+			}
+
+			try {
+				// If the Event is recurring, then move the "On" limit of any recurrence or exclusion rule.
+				$recurrence = get_post_meta( $event_post_id, '_EventRecurrence', true );
+				if ( ! empty( $recurrence ) && is_array( $recurrence ) ) {
+					$move_on_limit = static function ( array $rule ) use ( $interval, $is_subtraction, $timezone ): array {
+						if ( ! ( isset( $rule['end-type'], $rule['end'] ) && $rule['end-type'] === 'On' ) ) {
+							return $rule;
+						}
+
+						$date_time_immutable = Dates::immutable( $rule['end'], $timezone );
+						$rule['end'] = $is_subtraction ?
+							$date_time_immutable->sub( $interval )->format( 'Y-m-d' )
+							: $date_time_immutable->add( $interval )->format( 'Y-m-d' );
+
+						return $rule;
+					};
+
+					$recurrence['rules'] = array_map( $move_on_limit, ( $recurrence['rules'] ?? [] ) );
+					$recurrence['exclusions'] = array_map( $move_on_limit, ( $recurrence['exclusions'] ?? [] ) );
+					update_post_meta( $event_post_id, '_EventRecurrence', $recurrence );
+				}
+
+				// Refresh the Event model from the new post and meta data.
+				if ( Event::upsert( [ 'post_id' ], Event::data_from_post( $event_post_id ) ) === false ) {
+					WP_CLI::error( "Event model for ID {$event_post_id} could not be upserted." );
+				}
+
+				// Update the Event's occurrences: this will apply to Single and Recurring Events.
+				$event_model->occurrences()->save_occurrences();
+
+				// Declare the Event as updated.
+				$action = $is_subtraction ? 'decreased' : 'increased';
+				$action_value = $is_subtraction ? $sub : $add;
+				$new_start = get_post_meta( $event_post_id, '_EventStartDate', true );
+				$new_end = get_post_meta( $event_post_id, '_EventEndDate', true );
+				WP_CLI::success( "Event (ID: {$event_post_id}) dates were {$action} by {$action_value} to Start Date '{$new_start}' and End Date '{$new_end}'." );
+			} catch ( \Exception $e ) {
+				WP_CLI::error( "Error saving occurrences for event with post_id {$event_post_id}: {$e->getMessage()}" );
+			}
+		}
+	}
+
+	private function move_events( array $events, bool $is_subtraction, $sub, $add ): void {
+		foreach ( $events as $event ) {
+			if ( $is_subtraction ) {
+				list( $event_id, $new_start, $new_end ) = $this->move_event_backward( $event, $sub );
+				WP_CLI::success( "Event (ID: {$event_id}) dates were decreased by {$sub} to Start Date '{$new_start}' and End Date '{$new_end}'." );
+			} else {
+				list( $event_id, $new_start, $new_end ) = $this->move_event_forward( $event, $add );
+				WP_CLI::success( "Event (ID: {$event_id}) dates were increased by {$add} to Start Date '{$new_start}' and End Date '{$new_end}'." );
+			}
+		}
 	}
 }


### PR DESCRIPTION
Artifacts:
* [Classic Editor screencast](https://share.cleanshot.com/K1LQnM)
* [Blocks Editor screencast](https://share.cleanshot.com/KvbWM6)
* [Forward and backward move screencast](https://share.cleanshot.com/27l0sj)

This fix differentiates the logic of the `rotate` command to operate
correctly on the CT1 Events.
The implementation relies on some lower-level APIs (CT1 models) to
provide an immediate fix for the command.

In the context of TEC and ECP, some thinking should be given to how we
would like to support Event updates like the ones performed by the
command in the context of the ORM. I did not want to rush in a
a solution that would stick for a long time and rely, for that reason, on the
use of lower-level APIs.

Note: I've not broken down the method `move_ct1_events` method to make
it as readable as possible.
