### PR TITLE
Handle daylight saving correctly in CT1 rotation

### DIFF
--- a/src/Events/Control/CLI.php
+++ b/src/Events/Control/CLI.php
@@ -36,15 +36,13 @@ class CLI extends WP_CLI_Command {
 	 * ---
 	 *
 	 * [--add=<add>]
-	 * : Interval that should be added to the events found. Using DateInterval formatting.
-	 * (https://www.php.net/manual/en/dateinterval.format.php)
+	 * : Interval that should be added to the events found. Using DateInterval formatting. (https://www.php.net/manual/en/dateinterval.format.php)
 	 * ---
 	 * default: P7D
 	 * ---
 	 *
 	 * [--sub=<sub>]
-	 * : Interval that should be subtracted to the events found. Using DateInterval formatting.
-	 * (https://www.php.net/manual/en/dateinterval.format.php)
+	 * : Interval that should be subtracted to the events found. Using DateInterval formatting. (https://www.php.net/manual/en/dateinterval.format.php)
 	 * ---
 	 * default:
 	 * ---


### PR DESCRIPTION
This fixes the issue that would present itself when moving an Event, in
the context of the Event rotation, across a daylight-saving time
threshold: the UTC start and end date meta would not be calculated
correctly and the Model validation would fail.

Artifacts:
* [Blocks Editor test](https://share.cleanshot.com/2EMzE9)
* [Classic Editor test](https://share.cleanshot.com/8iqzi4)