### PR TITLE
fix(CLI) flush cache after event rotation

### DIFF
--- a/src/Events/Control/CLI.php
+++ b/src/Events/Control/CLI.php
@@ -82,6 +82,9 @@ class CLI extends WP_CLI_Command {
 		} else {
 			$this->move_events( $events, $is_subtraction, $sub, $add );
 		}
+
+		// Flush the site object cache after the move: flushing only selected posts' cache would not work.
+		wp_cache_flush();
 	}
 
 	protected function move_event_forward( $event, $by ) {


### PR DESCRIPTION
After Events have been moved, flush the site cache.
While heavy-handed, the relations between Event posts, Occurrence caches
and linked posts warrants a more widespread approach to the issue to
make sure new caches will be built correctly.
